### PR TITLE
Add import endpoint for GraalVM build stats

### DIFF
--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/adapter/StatsAdapter.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/adapter/StatsAdapter.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2022 Contributors to the Collector project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.redhat.quarkus.mandrel.collector.report.adapter;
+
+import com.redhat.quarkus.mandrel.collector.report.model.BuildPerformanceStats;
+import com.redhat.quarkus.mandrel.collector.report.model.ImageSizeStats;
+import com.redhat.quarkus.mandrel.collector.report.model.ImageStats;
+import com.redhat.quarkus.mandrel.collector.report.model.JNIAccessStats;
+import com.redhat.quarkus.mandrel.collector.report.model.ReachableImageStats;
+import com.redhat.quarkus.mandrel.collector.report.model.ReflectionRegistrationStats;
+import com.redhat.quarkus.mandrel.collector.report.model.TotalClassesStats;
+import com.redhat.quarkus.mandrel.collector.report.model.graal.DebugInfo;
+import com.redhat.quarkus.mandrel.collector.report.model.graal.GraalStats;
+
+public class StatsAdapter {
+    
+    public ImageStats adapt(GraalStats graalStat) {
+        ImageStats stats = new ImageStats(graalStat.getGenInfo().getName());
+        stats.setGraalVersion(graalStat.getGenInfo().getGraalVersion());
+        JNIAccessStats jni = new JNIAccessStats();
+        jni.setNumClasses(graalStat.getAnalysisResults().getClassStats().getJni());
+        jni.setNumMethods(graalStat.getAnalysisResults().getMethodStats().getJni());
+        jni.setNumFields(graalStat.getAnalysisResults().getFieldStats().getJni());
+        stats.setJniStats(jni);
+        TotalClassesStats total = new TotalClassesStats();
+        total.setNumClasses(graalStat.getAnalysisResults().getClassStats().getTotal());
+        total.setNumFields(graalStat.getAnalysisResults().getFieldStats().getTotal());
+        total.setNumMethods(graalStat.getAnalysisResults().getMethodStats().getTotal());
+        stats.setTotalStats(total);
+        ReflectionRegistrationStats ref = new ReflectionRegistrationStats();
+        ref.setNumClasses(graalStat.getAnalysisResults().getClassStats().getReflection());
+        ref.setNumMethods(graalStat.getAnalysisResults().getMethodStats().getReflection());
+        ref.setNumFields(graalStat.getAnalysisResults().getFieldStats().getReflection());
+        stats.setReflectionStats(ref);
+        ReachableImageStats reach = new ReachableImageStats();
+        reach.setNumClasses(graalStat.getAnalysisResults().getClassStats().getReachable());
+        reach.setNumMethods(graalStat.getAnalysisResults().getMethodStats().getReachable());
+        reach.setNumFields(graalStat.getAnalysisResults().getFieldStats().getReachable());
+        stats.setReachableStats(reach);
+        
+        ImageSizeStats size = new ImageSizeStats();
+        size.setCodeCacheSize(graalStat.getImageDetails().getCodeArea().getBytes());
+        DebugInfo debugInfo = graalStat.getImageDetails().getDebugInfo();
+        if (debugInfo != null) {
+            size.setDebuginfoSize(debugInfo.getBytes());
+        }
+        size.setHeapSize(graalStat.getImageDetails().getImageHeap().getBytes());
+        size.setTotalSize(graalStat.getImageDetails().getSizeBytes());
+        size.setOtherSize(calculateOtherSize(graalStat));
+        stats.setSizeStats(size);
+        
+        BuildPerformanceStats perfStats = new BuildPerformanceStats();
+        perfStats.setBuilderCpuLoad(graalStat.getResourceUsage().getCpu().getCpuLoad());
+        perfStats.setBuilderMachineMemTotal(graalStat.getResourceUsage().getMemory().getMachineTotal());
+        perfStats.setNumCpuCores(graalStat.getResourceUsage().getCpu().getCoresTotal());
+        perfStats.setPeakRSSBytes(graalStat.getResourceUsage().getMemory().getPeakRSS());
+        // Implement timing stats using '-H:+CollectImageBuildStatistics -H:ImageBuildStatisticsFile=foo.json'
+        // and parsing the resulting JSON for the value (GraalVM 22.2+)
+        perfStats.setTotalTimeSeconds(-1);
+        stats.setResourceStats(perfStats);
+        return stats;
+    }
+
+    private long calculateOtherSize(GraalStats graalStat) {
+        long total = graalStat.getImageDetails().getSizeBytes();
+        long heap = graalStat.getImageDetails().getImageHeap().getBytes();
+        long code = graalStat.getImageDetails().getCodeArea().getBytes();
+        long debugInfo = 0;
+        DebugInfo debugInfoObject = graalStat.getImageDetails().getDebugInfo();
+        if (debugInfoObject != null) {
+            debugInfo = debugInfoObject.getBytes();
+        }
+        return total - heap - code - debugInfo;
+    }
+}

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/endpoints/GraalImageStatsResource.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/endpoints/GraalImageStatsResource.java
@@ -1,0 +1,39 @@
+package com.redhat.quarkus.mandrel.collector.report.endpoints;
+
+import javax.annotation.security.RolesAllowed;
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+
+import com.redhat.quarkus.mandrel.collector.report.adapter.StatsAdapter;
+import com.redhat.quarkus.mandrel.collector.report.model.ImageStats;
+import com.redhat.quarkus.mandrel.collector.report.model.ImageStatsCollection;
+import com.redhat.quarkus.mandrel.collector.report.model.graal.GraalStats;
+
+@ApplicationScoped
+@Path("api/v1/image-stats")
+@Produces("application/json")
+@Consumes("application/json")
+public class GraalImageStatsResource {
+    
+    private static final StatsAdapter ADAPTER = new StatsAdapter();
+    private final ImageStatsCollection collection;
+    
+    public GraalImageStatsResource(ImageStatsCollection collection) {
+        this.collection = collection;
+    }
+    
+    @RolesAllowed("token_write")
+    @Path("import")
+    @POST
+    public ImageStats importStat(GraalStats importStat, @QueryParam("t") String tag) {
+        ImageStats stat = ADAPTER.adapt(importStat);
+        if (tag != null) {
+            stat.setTag(tag);
+        }
+        return collection.add(stat);
+    }
+}

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/AnalysisResults.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/AnalysisResults.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022 Contributors to the Collector project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.redhat.quarkus.mandrel.collector.report.model.graal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AnalysisResults {
+
+    @JsonProperty("classes")
+    private ExecutableStats classStats;
+    @JsonProperty("fields")
+    private ExecutableStats fieldStats;
+    @JsonProperty("methods")
+    private ExecutableStats methodStats;
+    
+    public ExecutableStats getClassStats() {
+        return classStats;
+    }
+    public void setClassStats(ExecutableStats classStats) {
+        this.classStats = classStats;
+    }
+    public ExecutableStats getFieldStats() {
+        return fieldStats;
+    }
+    public void setFieldStats(ExecutableStats fieldStats) {
+        this.fieldStats = fieldStats;
+    }
+    public ExecutableStats getMethodStats() {
+        return methodStats;
+    }
+    public void setMethodStats(ExecutableStats methodStats) {
+        this.methodStats = methodStats;
+    }
+}

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/CPUInfo.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/CPUInfo.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022 Contributors to the Collector project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.redhat.quarkus.mandrel.collector.report.model.graal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CPUInfo {
+
+    @JsonProperty("total_cores")
+    private long coresTotal;
+    
+    @JsonProperty("load")
+    private double cpuLoad;
+
+    public long getCoresTotal() {
+        return coresTotal;
+    }
+
+    public void setCoresTotal(long coresTotal) {
+        this.coresTotal = coresTotal;
+    }
+
+    public double getCpuLoad() {
+        return cpuLoad;
+    }
+
+    public void setCpuLoad(double cpuLoad) {
+        this.cpuLoad = cpuLoad;
+    }
+}

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/CodeArea.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/CodeArea.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022 Contributors to the Collector project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.redhat.quarkus.mandrel.collector.report.model.graal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CodeArea extends SizeableMetric {
+
+    @JsonProperty("compilation_units")
+    private long compUnits;
+
+    public long getCompUnits() {
+        return compUnits;
+    }
+
+    public void setCompUnits(long compUnits) {
+        this.compUnits = compUnits;
+    }
+}

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/DebugInfo.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/DebugInfo.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022 Contributors to the Collector project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.redhat.quarkus.mandrel.collector.report.model.graal;
+
+public class DebugInfo extends SizeableMetric {
+
+}

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/ExecutableStats.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/ExecutableStats.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022 Contributors to the Collector project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.redhat.quarkus.mandrel.collector.report.model.graal;
+
+public class ExecutableStats {
+
+    private long total;
+    private long reachable;
+    private long reflection;
+    private long jni;
+    
+    public long getTotal() {
+        return total;
+    }
+    public void setTotal(long total) {
+        this.total = total;
+    }
+    public long getReachable() {
+        return reachable;
+    }
+    public void setReachable(long reachable) {
+        this.reachable = reachable;
+    }
+    public long getReflection() {
+        return reflection;
+    }
+    public void setReflection(long reflection) {
+        this.reflection = reflection;
+    }
+    public long getJni() {
+        return jni;
+    }
+    public void setJni(long jni) {
+        this.jni = jni;
+    }
+    
+}

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/GCInfo.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/GCInfo.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022 Contributors to the Collector project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.redhat.quarkus.mandrel.collector.report.model.graal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class GCInfo {
+
+    @JsonProperty("count")
+    private long count;
+    
+    @JsonProperty("total_secs")
+    private double totalSecs;
+
+    public long getCount() {
+        return count;
+    }
+
+    public void setCount(long count) {
+        this.count = count;
+    }
+
+    public double getTotalSecs() {
+        return totalSecs;
+    }
+
+    public void setTotalSecs(double totalSecs) {
+        this.totalSecs = totalSecs;
+    }
+}

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/GeneralInfo.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/GeneralInfo.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022 Contributors to the Collector project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.redhat.quarkus.mandrel.collector.report.model.graal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class GeneralInfo {
+
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("c_compiler")
+    private String cCompiler;
+    @JsonProperty("java_version")
+    private String javaVersion;
+    @JsonProperty("garbage_collector")
+    private String garbageCollector;
+    @JsonProperty("graalvm_version")
+    private String graalVersion;
+    
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+    public String getCCompiler() {
+        return cCompiler;
+    }
+    public void setCCompiler(String cCompiler) {
+        this.cCompiler = cCompiler;
+    }
+    public String getJavaVersion() {
+        return javaVersion;
+    }
+    public void setJavaVersion(String javaVersion) {
+        this.javaVersion = javaVersion;
+    }
+    public String getGarbageCollector() {
+        return garbageCollector;
+    }
+    public void setGarbageCollector(String garbageCollector) {
+        this.garbageCollector = garbageCollector;
+    }
+    public String getGraalVersion() {
+        return graalVersion;
+    }
+    public void setGraalVersion(String graalVersion) {
+        this.graalVersion = graalVersion;
+    }
+}

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/GraalStats.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/GraalStats.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2022 Contributors to the Collector project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.redhat.quarkus.mandrel.collector.report.model.graal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class GraalStats {
+
+    @JsonProperty("general_info")
+    private GeneralInfo genInfo;
+    
+    @JsonProperty("analysis_results")
+    private AnalysisResults analysisResults;
+    
+    @JsonProperty("image_details")
+    private ImageDetails imageDetails;
+    
+    @JsonProperty("resource_usage")
+    private ResourceUsage resourceUsage;
+
+    public GeneralInfo getGenInfo() {
+        return genInfo;
+    }
+
+    public void setGenInfo(GeneralInfo genInfo) {
+        this.genInfo = genInfo;
+    }
+
+    public AnalysisResults getAnalysisResults() {
+        return analysisResults;
+    }
+
+    public void setAnalysisResults(AnalysisResults analysisResults) {
+        this.analysisResults = analysisResults;
+    }
+
+    public ImageDetails getImageDetails() {
+        return imageDetails;
+    }
+
+    public void setImageDetails(ImageDetails imageDetails) {
+        this.imageDetails = imageDetails;
+    }
+
+    public ResourceUsage getResourceUsage() {
+        return resourceUsage;
+    }
+
+    public void setResourceUsage(ResourceUsage resourceUsage) {
+        this.resourceUsage = resourceUsage;
+    }
+}

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/ImageDetails.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/ImageDetails.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022 Contributors to the Collector project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.redhat.quarkus.mandrel.collector.report.model.graal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ImageDetails {
+
+    @JsonProperty("total_bytes")
+    private long sizeBytes;
+    @JsonProperty("debug_info")
+    private DebugInfo debugInfo;
+    @JsonProperty("code_area")
+    private CodeArea codeArea;
+    @JsonProperty("image_heap")
+    private ImageHeap imageHeap;
+    
+    public long getSizeBytes() {
+        return sizeBytes;
+    }
+    public void setSizeBytes(long sizeBytes) {
+        this.sizeBytes = sizeBytes;
+    }
+    public DebugInfo getDebugInfo() {
+        return debugInfo;
+    }
+    public void setDebugInfo(DebugInfo debugInfo) {
+        this.debugInfo = debugInfo;
+    }
+    public CodeArea getCodeArea() {
+        return codeArea;
+    }
+    public void setCodeArea(CodeArea codeArea) {
+        this.codeArea = codeArea;
+    }
+    public ImageHeap getImageHeap() {
+        return imageHeap;
+    }
+    public void setImageHeap(ImageHeap imageHeap) {
+        this.imageHeap = imageHeap;
+    }
+}

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/ImageHeap.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/ImageHeap.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022 Contributors to the Collector project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.redhat.quarkus.mandrel.collector.report.model.graal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ImageHeap extends SizeableMetric {
+
+    @JsonProperty("resources")
+    private ResourcesInfo resources;
+
+    public ResourcesInfo getResources() {
+        return resources;
+    }
+
+    public void setResources(ResourcesInfo resources) {
+        this.resources = resources;
+    }
+}

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/MemoryInfo.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/MemoryInfo.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022 Contributors to the Collector project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.redhat.quarkus.mandrel.collector.report.model.graal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class MemoryInfo {
+
+    @JsonProperty("system_total")
+    private long machineTotal;
+    @JsonProperty("peak_rss_bytes")
+    private long peakRSS;
+    
+    public long getMachineTotal() {
+        return machineTotal;
+    }
+    public void setMachineTotal(long machineTotal) {
+        this.machineTotal = machineTotal;
+    }
+    public long getPeakRSS() {
+        return peakRSS;
+    }
+    public void setPeakRSS(long peakRSS) {
+        this.peakRSS = peakRSS;
+    }
+}

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/ResourceUsage.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/ResourceUsage.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022 Contributors to the Collector project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.redhat.quarkus.mandrel.collector.report.model.graal;
+
+public class ResourceUsage {
+
+    private MemoryInfo memory;
+    private GCInfo gc;
+    private CPUInfo cpu;
+    
+    public MemoryInfo getMemory() {
+        return memory;
+    }
+    public void setMemory(MemoryInfo memory) {
+        this.memory = memory;
+    }
+    public GCInfo getGc() {
+        return gc;
+    }
+    public void setGc(GCInfo gc) {
+        this.gc = gc;
+    }
+    public CPUInfo getCpu() {
+        return cpu;
+    }
+    public void setCpu(CPUInfo cpu) {
+        this.cpu = cpu;
+    }
+}

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/ResourcesInfo.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/ResourcesInfo.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 Contributors to the Collector project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.redhat.quarkus.mandrel.collector.report.model.graal;
+
+public class ResourcesInfo extends SizeableMetric {
+
+    private long count;
+
+    public long getCount() {
+        return count;
+    }
+
+    public void setCount(long count) {
+        this.count = count;
+    }
+}

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/SizeableMetric.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/SizeableMetric.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022 Contributors to the Collector project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.redhat.quarkus.mandrel.collector.report.model.graal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public abstract class SizeableMetric {
+    
+    @JsonProperty("bytes")
+    private long bytes;
+
+    public long getBytes() {
+        return bytes;
+    }
+
+    public void setBytes(long bytes) {
+        this.bytes = bytes;
+    }
+
+}

--- a/src/test/java/com/redhat/quarkus/mandrel/collector/report/adapter/StatsAdapterTest.java
+++ b/src/test/java/com/redhat/quarkus/mandrel/collector/report/adapter/StatsAdapterTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2022 Contributors to the Collector project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.redhat.quarkus.mandrel.collector.report.adapter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+import com.redhat.quarkus.mandrel.collector.report.model.BuildPerformanceStats;
+import com.redhat.quarkus.mandrel.collector.report.model.ImageSizeStats;
+import com.redhat.quarkus.mandrel.collector.report.model.ImageStats;
+import com.redhat.quarkus.mandrel.collector.report.model.JNIAccessStats;
+import com.redhat.quarkus.mandrel.collector.report.model.ReachableImageStats;
+import com.redhat.quarkus.mandrel.collector.report.model.ReflectionRegistrationStats;
+import com.redhat.quarkus.mandrel.collector.report.model.TotalClassesStats;
+import com.redhat.quarkus.mandrel.collector.report.model.graal.AnalysisResults;
+import com.redhat.quarkus.mandrel.collector.report.model.graal.CPUInfo;
+import com.redhat.quarkus.mandrel.collector.report.model.graal.CodeArea;
+import com.redhat.quarkus.mandrel.collector.report.model.graal.DebugInfo;
+import com.redhat.quarkus.mandrel.collector.report.model.graal.ExecutableStats;
+import com.redhat.quarkus.mandrel.collector.report.model.graal.GCInfo;
+import com.redhat.quarkus.mandrel.collector.report.model.graal.GeneralInfo;
+import com.redhat.quarkus.mandrel.collector.report.model.graal.GraalStats;
+import com.redhat.quarkus.mandrel.collector.report.model.graal.ImageDetails;
+import com.redhat.quarkus.mandrel.collector.report.model.graal.ImageHeap;
+import com.redhat.quarkus.mandrel.collector.report.model.graal.MemoryInfo;
+import com.redhat.quarkus.mandrel.collector.report.model.graal.ResourceUsage;
+import com.redhat.quarkus.mandrel.collector.report.model.graal.ResourcesInfo;
+
+public class StatsAdapterTest {
+    
+    private static final StatsAdapter ADAPTER = new StatsAdapter();
+    
+    @Test
+    public void canAdaptGraalToImageStats() {
+        doTest(true);
+        doTest(false);
+    }
+    
+    private void doTest(boolean withDebugInfo) {
+        GraalStats stat = produceGraalStat(withDebugInfo);
+
+        ImageStats imStat = ADAPTER.adapt(stat);
+
+        assertNotNull(imStat);
+        assertEquals(stat.getGenInfo().getGraalVersion(), imStat.getGraalVersion());
+        assertEquals(stat.getGenInfo().getName(), imStat.getImageName());
+
+        JNIAccessStats jniStat = imStat.getJniStats();
+        assertNotNull(jniStat);
+        assertEquals(stat.getAnalysisResults().getClassStats().getJni(), jniStat.getNumClasses());
+        assertEquals(stat.getAnalysisResults().getMethodStats().getJni(), jniStat.getNumMethods());
+        assertEquals(stat.getAnalysisResults().getFieldStats().getJni(), jniStat.getNumFields());
+
+        TotalClassesStats totalStat = imStat.getTotalStats();
+        assertNotNull(totalStat);
+        assertEquals(stat.getAnalysisResults().getClassStats().getTotal(), totalStat.getNumClasses());
+        assertEquals(stat.getAnalysisResults().getMethodStats().getTotal(), totalStat.getNumMethods());
+        assertEquals(stat.getAnalysisResults().getFieldStats().getTotal(), totalStat.getNumFields());
+
+        ReflectionRegistrationStats reflStats = imStat.getReflectionStats();
+        assertNotNull(reflStats);
+        assertEquals(stat.getAnalysisResults().getClassStats().getReflection(), reflStats.getNumClasses());
+        assertEquals(stat.getAnalysisResults().getMethodStats().getReflection(), reflStats.getNumMethods());
+        assertEquals(stat.getAnalysisResults().getFieldStats().getReflection(), reflStats.getNumFields());
+
+        ReachableImageStats reachSt = imStat.getReachableStats();
+        assertNotNull(reachSt);
+        assertEquals(stat.getAnalysisResults().getClassStats().getReachable(), reachSt.getNumClasses());
+        assertEquals(stat.getAnalysisResults().getMethodStats().getReachable(), reachSt.getNumMethods());
+        assertEquals(stat.getAnalysisResults().getFieldStats().getReachable(), reachSt.getNumFields());
+
+        ImageSizeStats sizeStat = imStat.getSizeStats();
+        assertNotNull(sizeStat);
+        assertEquals(stat.getImageDetails().getCodeArea().getBytes(), sizeStat.getCodeCacheSize());
+        if (withDebugInfo) {
+            assertEquals(stat.getImageDetails().getDebugInfo().getBytes(), sizeStat.getDebuginfoSize());
+        } else {
+            assertNull(stat.getImageDetails().getDebugInfo());
+            assertEquals(0, sizeStat.getDebuginfoSize());
+        }
+        assertEquals(stat.getImageDetails().getImageHeap().getBytes(), sizeStat.getHeapSize());
+        assertEquals(calculateOtherBytes(stat, withDebugInfo), sizeStat.getOtherSize());
+        assertEquals(stat.getImageDetails().getSizeBytes(), sizeStat.getTotalSize());
+
+        BuildPerformanceStats perfStats = imStat.getResourceStats();
+        assertNotNull(sizeStat);
+        assertEquals(stat.getResourceUsage().getCpu().getCpuLoad(), perfStats.getBuilderCpuLoad());
+        assertEquals(stat.getResourceUsage().getCpu().getCoresTotal(), perfStats.getNumCpuCores());
+        assertEquals(stat.getResourceUsage().getMemory().getPeakRSS(), perfStats.getPeakRSSBytes());
+        assertEquals(stat.getResourceUsage().getMemory().getMachineTotal(), perfStats.getBuilderMachineMemTotal());
+    }
+
+    private Long calculateOtherBytes(GraalStats stat, boolean withDebugInfo) {
+        long debugInfoBytes = 0;
+        if (withDebugInfo) {
+            debugInfoBytes = stat.getImageDetails().getDebugInfo().getBytes(); 
+        }
+        long total = stat.getImageDetails().getSizeBytes();
+        return total - ( stat.getImageDetails().getCodeArea().getBytes() + 
+                debugInfoBytes +
+                stat.getImageDetails().getImageHeap().getBytes());
+    }
+
+    private GraalStats produceGraalStat(boolean withDebugInfo) {
+        GraalStats s = new GraalStats();
+        GeneralInfo general = new GeneralInfo();
+        general.setCCompiler("GCC");
+        general.setGarbageCollector("Serial GC");
+        general.setName("helloworld");
+        general.setGraalVersion("Mandrel 22.3-dev, Java 11");
+        CPUInfo cpuInfo = new CPUInfo();
+        cpuInfo.setCoresTotal(8);
+        cpuInfo.setCpuLoad(6.8);
+        MemoryInfo memInfo = new MemoryInfo();
+        memInfo.setMachineTotal(1000_000);
+        memInfo.setPeakRSS(500_000);
+        GCInfo gcInfo = new GCInfo();
+        gcInfo.setCount(17);
+        gcInfo.setTotalSecs(0.20);
+        ResourceUsage usage = new ResourceUsage();
+        usage.setCpu(cpuInfo);
+        usage.setMemory(memInfo);
+        usage.setGc(gcInfo);
+        
+        AnalysisResults analysis = new AnalysisResults();
+        ExecutableStats classStats = new ExecutableStats();
+        classStats.setJni(10);
+        classStats.setReflection(1222);
+        classStats.setTotal(2000);
+        classStats.setReachable(1800);
+        analysis.setClassStats(classStats);
+        ExecutableStats methodStats = new ExecutableStats();
+        methodStats.setJni(2);
+        methodStats.setReflection(121);
+        methodStats.setTotal(330);
+        methodStats.setReachable(300);
+        analysis.setMethodStats(methodStats);
+        ExecutableStats fieldStats = new ExecutableStats();
+        fieldStats.setJni(3);
+        fieldStats.setReachable(30);
+        fieldStats.setTotal(500);
+        fieldStats.setReachable(302);
+        analysis.setFieldStats(fieldStats);
+        
+        ImageDetails imageDetails = new ImageDetails();
+        imageDetails.setSizeBytes(300_000);
+        CodeArea codeArea = new CodeArea();
+        codeArea.setBytes(100_000);
+        codeArea.setCompUnits(1234);
+        ImageHeap heap = new ImageHeap();
+        heap.setBytes(120_000);
+        ResourcesInfo resInfo = new ResourcesInfo();
+        resInfo.setBytes(20_000);
+        resInfo.setCount(10);
+        heap.setResources(resInfo);
+        if (withDebugInfo) {
+            DebugInfo info = new DebugInfo();
+            info.setBytes(0);
+            imageDetails.setDebugInfo(info);
+        }
+
+        imageDetails.setImageHeap(heap);
+        imageDetails.setCodeArea(codeArea);
+        
+        s.setGenInfo(general);
+        s.setResourceUsage(usage);
+        s.setAnalysisResults(analysis);
+        s.setImageDetails(imageDetails);
+        return s;
+    }
+
+}

--- a/src/test/java/com/redhat/quarkus/mandrel/collector/report/endpoints/GraalImageStatsResourceTest.java
+++ b/src/test/java/com/redhat/quarkus/mandrel/collector/report/endpoints/GraalImageStatsResourceTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2022 Contributors to the Collector project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.redhat.quarkus.mandrel.collector.report.endpoints;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.redhat.quarkus.mandrel.collector.report.endpoints.StatsTestHelper.Mode;
+import com.redhat.quarkus.mandrel.collector.report.model.ImageStats;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.parsing.Parser;
+import io.restassured.response.ResponseBody;
+
+@QuarkusTest
+public class GraalImageStatsResourceTest {
+
+    private static final List<Long> idsToDelete = new ArrayList<>();
+    
+    @BeforeAll
+    public static void setup() {
+        RestAssured.defaultParser = Parser.JSON;
+    }
+    
+    @Test
+    public void testImport() throws Exception {
+        String json = createGraalJSON();
+        String token = StatsTestHelper.login(Mode.READ_WRITE);
+        ResponseBody<?> body = given().contentType(ContentType.JSON).header("token", token).body(json)
+                .when().post(StatsTestHelper.BASE_URL + "/import").body();
+        ImageStats result = body.as(ImageStats.class);
+        
+        assertTrue(result.getId() > 0);
+        assertEquals("foo-bar", result.getImageName());
+        assertEquals("GraalVM 22.3.0-dev Java 11 Mandrel Distribution", result.getGraalVersion());
+        idsToDelete.add(result.getId());
+        
+        // Ensure we can listOne the result
+        given().contentType(ContentType.JSON).header("token", token).when().get(StatsTestHelper.BASE_URL + "/" + result.getId()).then()
+            .statusCode(200).body(
+                    containsString(result.getImageName()),
+                    containsString(result.getGraalVersion()));
+    }
+    
+    @AfterEach
+    public void delete() {
+        // Delete the created resources again
+        String token = StatsTestHelper.login(Mode.READ_WRITE);
+        for (Long id: idsToDelete) {
+            given().contentType(ContentType.JSON).header("token", token).when().delete(StatsTestHelper.BASE_URL + "/" + id).then()
+                .statusCode(200);
+        }
+    }
+
+    private String createGraalJSON() {
+        return "{\n"
+                + "  \"resource_usage\": {\n"
+                + "    \"memory\": {\n"
+                + "      \"system_total\": 33260355584,\n"
+                + "      \"peak_rss_bytes\": 3127443456\n"
+                + "    },\n"
+                + "    \"garbage_collection\": {\n"
+                + "      \"count\": 20,\n"
+                + "      \"total_secs\": 1.097\n"
+                + "    },\n"
+                + "    \"cpu\": {\n"
+                + "      \"load\": 6.307451297470753,\n"
+                + "      \"total_cores\": 8\n"
+                + "    }\n"
+                + "  },\n"
+                + "  \"image_details\": {\n"
+                + "    \"debug_info\": {\n"
+                + "      \"bytes\": 7694974\n"
+                + "    },\n"
+                + "    \"code_area\": {\n"
+                + "      \"bytes\": 4181808,\n"
+                + "      \"compilation_units\": 7040\n"
+                + "    },\n"
+                + "    \"total_bytes\": 20157545,\n"
+                + "    \"image_heap\": {\n"
+                + "      \"bytes\": 7233536,\n"
+                + "      \"resources\": {\n"
+                + "        \"bytes\": 142884,\n"
+                + "        \"count\": 5\n"
+                + "      }\n"
+                + "    }\n"
+                + "  },\n"
+                + "  \"general_info\": {\n"
+                + "    \"c_compiler\": \"gcc (redhat, x86_64, 11.3.1)\",\n"
+                + "    \"name\": \"foo-bar\",\n"
+                + "    \"java_version\": null,\n"
+                + "    \"garbage_collector\": \"Serial GC\",\n"
+                + "    \"graalvm_version\": \"GraalVM 22.3.0-dev Java 11 Mandrel Distribution\"\n"
+                + "  },\n"
+                + "  \"analysis_results\": {\n"
+                + "    \"methods\": {\n"
+                + "      \"total\": 27123,\n"
+                + "      \"reflection\": 267,\n"
+                + "      \"jni\": 52,\n"
+                + "      \"reachable\": 12255\n"
+                + "    },\n"
+                + "    \"classes\": {\n"
+                + "      \"total\": 3725,\n"
+                + "      \"reflection\": 27,\n"
+                + "      \"jni\": 58,\n"
+                + "      \"reachable\": 2709\n"
+                + "    },\n"
+                + "    \"fields\": {\n"
+                + "      \"total\": 6388,\n"
+                + "      \"reflection\": 0,\n"
+                + "      \"jni\": -1,\n"
+                + "      \"reachable\": 3430\n"
+                + "    }\n"
+                + "  }\n"
+                + "}";
+    }
+}
+
+    

--- a/src/test/java/com/redhat/quarkus/mandrel/collector/report/endpoints/GraalImageStatsResourceTestIT.java
+++ b/src/test/java/com/redhat/quarkus/mandrel/collector/report/endpoints/GraalImageStatsResourceTestIT.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 Contributors to the Collector project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.redhat.quarkus.mandrel.collector.report.endpoints;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class GraalImageStatsResourceTestIT extends GraalImageStatsResourceTest {
+
+}

--- a/src/test/java/com/redhat/quarkus/mandrel/collector/report/endpoints/StatsTestHelper.java
+++ b/src/test/java/com/redhat/quarkus/mandrel/collector/report/endpoints/StatsTestHelper.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2022 Contributors to the Collector project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.redhat.quarkus.mandrel.collector.report.endpoints;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.apache.http.HttpStatus;
+
+import io.restassured.RestAssured;
+import io.restassured.filter.cookie.CookieFilter;
+import io.restassured.http.ContentType;
+
+public class StatsTestHelper {
+
+    static final String BASE_URL = "/api/v1/image-stats";
+
+    static enum Mode {
+
+        READ("r"),
+        READ_WRITE("rw"),
+        WRITE("w");
+
+        private String mode;
+
+        private Mode(String mode) {
+            this.mode = mode;
+        }
+
+        String getMode() {
+            return mode;
+        }
+    }
+    
+    public static String login(Mode mode) {
+        final CookieFilter cookies = new CookieFilter();
+        // Login
+        RestAssured.given()
+                .filter(cookies)
+                .contentType(ContentType.URLENC)
+                .body("j_username=user&j_password=This is my password.")
+                .post("/j_security_check").then().statusCode(HttpStatus.SC_MOVED_TEMPORARILY);
+        // Authenticated request, only 'user' user can create tokens for now.
+        RestAssured.given()
+                .filter(cookies).when().get("/api/user/me").then()
+                .body(is("user")).statusCode(HttpStatus.SC_OK);
+
+        // Generate a new token
+        final String token = RestAssured.given()
+                .filter(cookies).when().post("/api/tokens/create/" + mode.getMode()).then()
+                .statusCode(HttpStatus.SC_CREATED)
+                .body("message", containsString("Save the token safely. This is the only time"))
+                .extract().path("token");
+        return token;
+    }
+}


### PR DESCRIPTION
Support importing metrics as produced by https://github.com/oracle/graal/pull/4685

Example usage:
```
curl -w '\n' -H "token: 10fe0d58bdcccddcadda64ee2fc195a5b3c18cc8ba4661b77ca1c9383109d82d15fc4e86d73a637ff199379bb2251796db997d718cfe81e97bb5e10b9098562f" -H "Content-Type: application/json" --post302 --data @$(pwd)/build-stats.json http://127.0.0.1:8080/api/v1/image-stats/import
{"id":1,"created_at":"2022-06-30T17:29:38.141+00:00","tag":null,"img_name":"hello","generator_version":"GraalVM 22.3.0-dev Java 11 Mandrel Distribution","image_size_stats":{"id":1,"total_bytes":12464150,"code_cache_bytes":4181632,"heap_bytes":7233536,"other_bytes":1048982,"debuginfo_bytes":0},"jni_classes_stats":{"id":1,"classes":58,"fields":58,"methods":52},"reflection_stats":{"id":3,"classes":27,"fields":0,"methods":267},"build_perf_stats":{"id":1,"total_build_time_sec":-1.0,"num_cpu_cores":8,"total_machine_memory":33258110976,"peak_rss_bytes":2911281152,"cpu_load":6.414419832280913},"total_classes_stats":{"id":4,"classes":3725,"fields":6388,"methods":27122},"reachability_stats":{"id":2,"classes":2709,"fields":3430,"methods":12255}}
```