### PR TITLE
Add PUT updater for build time seconds

### DIFF
--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/adapter/StatsAdapter.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/adapter/StatsAdapter.java
@@ -72,8 +72,8 @@ public class StatsAdapter {
         perfStats.setBuilderMachineMemTotal(graalStat.getResourceUsage().getMemory().getMachineTotal());
         perfStats.setNumCpuCores(graalStat.getResourceUsage().getCpu().getCoresTotal());
         perfStats.setPeakRSSBytes(graalStat.getResourceUsage().getMemory().getPeakRSS());
-        // Implement timing stats using '-H:+CollectImageBuildStatistics -H:ImageBuildStatisticsFile=foo.json'
-        // and parsing the resulting JSON for the value (GraalVM 22.2+)
+        // Timing information needs to be updated using the PUT endpoint
+        // of api/v1/image-stats/<id>
         perfStats.setTotalTimeSeconds(-1);
         stats.setResourceStats(perfStats);
         return stats;

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/endpoints/ImageStatsResource.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/endpoints/ImageStatsResource.java
@@ -27,12 +27,14 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
@@ -42,6 +44,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.redhat.quarkus.mandrel.collector.report.model.ImageStats;
 import com.redhat.quarkus.mandrel.collector.report.model.ImageStatsCollection;
+import com.redhat.quarkus.mandrel.collector.report.model.graal.GraalBuildInfo;
 
 @ApplicationScoped
 @Path("api/v1/image-stats")
@@ -93,6 +96,17 @@ public class ImageStatsResource {
             stat.setTag(tag);
         }
         return collection.add(stat);
+    }
+    
+    @RolesAllowed("token_write")
+    @PUT
+    @Path("{statId:\\d+}")
+    public ImageStats updateBuildTime(@PathParam("statId") Long statId, GraalBuildInfo info) {
+        ImageStats stat = collection.updateBuildTime(statId, info.getTotalBuildTimeMilis());
+        if (stat == null) {
+            throw new WebApplicationException("Stat with id " + statId + " not found", Status.NOT_FOUND);
+        }
+        return stat;
     }
 
     @RolesAllowed("token_write")

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/ImageStatsCollection.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/ImageStatsCollection.java
@@ -80,4 +80,18 @@ public class ImageStatsCollection {
         }
         return removed.toArray(new ImageStats[0]);
     }
+    
+    @Transactional
+    public ImageStats updateBuildTime(long id, long buildTimeMilis) {
+        ImageStats stat = getSingle(id);
+        if (stat == null) {
+            return null;
+        }
+        if (buildTimeMilis != 0) {
+            BuildPerformanceStats perfStats = stat.getResourceStats();
+            double buildTimeSec = ((double)buildTimeMilis) / 1000;
+            perfStats.setTotalTimeSeconds(buildTimeSec);
+        }
+        return stat;
+    }
 }

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/GraalBuildInfo.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/GraalBuildInfo.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022 Contributors to the Collector project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.redhat.quarkus.mandrel.collector.report.model.graal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Object representing the JSON output of GraalVM's
+ * -H:+CollectImageBuildStatistics -H:ImageBuildStatisticsFile=foo.json
+ *
+ * For now this only retrieves the total build time.
+ */
+public class GraalBuildInfo {
+
+    // Available in GraalVM 22.2+ (at least not available in 21.3)
+    @JsonProperty("total_time")
+    private long totalBuildTimeMilis;
+
+    public long getTotalBuildTimeMilis() {
+        return totalBuildTimeMilis;
+    }
+
+    public void setTotalBuildTimeMilis(long totalBuildTimeMilis) {
+        this.totalBuildTimeMilis = totalBuildTimeMilis;
+    }
+}


### PR DESCRIPTION
GraalVM 22.2+ (I think) has options `-H:+CollectImageBuildStatistics -H:ImageBuildStatisticsFile=foo.json` which if passed to the build collects timing information in JSON format. It also includes the `total_time` (in miliseconds) of the image build. This patch adds an endpoint for setting the build time in the collected (and persisted) stat.

Example workflow:

Import the stats from ProgressReporter in GraalVM:
```
$ curl -v -w '\n' -H "Content-Type: application/json" -H "token: 8cd729174d6924c6e9651bb8c9435c288a9967daee9a0f3387cdc111cbccc8a132a32f7433dc321dd54e0f7c4850f3018e587db008357317027218f19a437879" --post302 --data @/disk/graal/upstream-sources/graal/hello-stats.json http://127.0.0.1:8080/api/v1/image-stats/import | jq .id
```

Update the build time:

```
$ curl -v -w '\n' -H "Content-Type: application/json" -H "token: 8cd729174d6924c6e9651bb8c9435c288a9967daee9a0f3387cdc111cbccc8a132a32f7433dc321dd54e0f7c4850f3018e587db008357317027218f19a437879" -X PUT --data @/disk/graal/upstream-sources/graal/hello-build-stats.json http://127.0.0.1:8080/api/v1/image-stats/1 | jq
{
  "id": 1,
  "created_at": "2022-07-05T13:45:23.929+00:00",
  "tag": null,
  "img_name": "hello",
  "generator_version": "GraalVM 22.3.0-dev Java 11 Mandrel Distribution",
  "image_size_stats": {
    "id": 1,
    "total_bytes": 12464158,
    "code_cache_bytes": 4181824,
    "heap_bytes": 7233536,
    "other_bytes": 1048798,
    "debuginfo_bytes": 0
  },
  "jni_classes_stats": {
    "id": 1,
    "classes": 58,
    "fields": 58,
    "methods": 52
  },
  "reflection_stats": {
    "id": 3,
    "classes": 27,
    "fields": 0,
    "methods": 267
  },
  "build_perf_stats": {
    "id": 1,
    "total_build_time_sec": 31.709,
    "num_cpu_cores": 8,
    "total_machine_memory": 33257771008,
    "peak_rss_bytes": 3084926976,
    "cpu_load": 6.466114271580508
  },
  "total_classes_stats": {
    "id": 4,
    "classes": 3744,
    "fields": 6389,
    "methods": 27202
  },
  "reachability_stats": {
    "id": 2,
    "classes": 2714,
    "fields": 3430,
    "methods": 12261
  }
}
```