### PR TITLE
Handle imports coming from 0.9.1 and 0.9.0 schema

### DIFF
--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/adapter/StatsAdapter.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/adapter/StatsAdapter.java
@@ -72,9 +72,16 @@ public class StatsAdapter {
         perfStats.setBuilderMachineMemTotal(graalStat.getResourceUsage().getMemory().getMachineTotal());
         perfStats.setNumCpuCores(graalStat.getResourceUsage().getCpu().getCoresTotal());
         perfStats.setPeakRSSBytes(graalStat.getResourceUsage().getMemory().getPeakRSS());
-        // Timing information needs to be updated using the PUT endpoint
-        // of api/v1/image-stats/<id>
-        perfStats.setTotalTimeSeconds(-1);
+        // Schema 0.9.1 added total time to the graal stats
+        double totalTimeSec = graalStat.getResourceUsage().getTotalTimeSecs();
+        if (totalTimeSec > 0) {
+            perfStats.setTotalTimeSeconds(totalTimeSec);
+        } else {
+            // Schema 0.9.0 (22.3):
+            // Timing information needs to be updated using the PUT endpoint
+            // of api/v1/image-stats/<id>
+            perfStats.setTotalTimeSeconds(-1);
+        }
         stats.setResourceStats(perfStats);
         return stats;
     }

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/AnalysisResults.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/AnalysisResults.java
@@ -24,18 +24,32 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class AnalysisResults {
 
+    // 0.9.0 schema used 'classes'
     @JsonProperty("classes")
     private ExecutableStats classStats;
+    // 0.9.1 schema uses 'types'
+    @JsonProperty("types")
+    private ExecutableStats typeStats;
     @JsonProperty("fields")
     private ExecutableStats fieldStats;
     @JsonProperty("methods")
     private ExecutableStats methodStats;
     
     public ExecutableStats getClassStats() {
+        // Prefer newer type stats over older class stats
+        if (typeStats != null) {
+            return typeStats;
+        }
         return classStats;
     }
     public void setClassStats(ExecutableStats classStats) {
         this.classStats = classStats;
+    }
+    public ExecutableStats getTypeStats() {
+        return typeStats;
+    }
+    public void setTypeStats(ExecutableStats typeStats) {
+        this.typeStats = typeStats;
     }
     public ExecutableStats getFieldStats() {
         return fieldStats;

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/ResourceUsage.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/graal/ResourceUsage.java
@@ -20,12 +20,27 @@
 
 package com.redhat.quarkus.mandrel.collector.report.model.graal;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class ResourceUsage {
 
+    private static final double UNSET = -1;
+    @JsonProperty("total_secs")
+    private double totalTimeSecs;
     private MemoryInfo memory;
     private GCInfo gc;
     private CPUInfo cpu;
     
+    public ResourceUsage() {
+        this.totalTimeSecs = UNSET;
+    }
+    
+    public double getTotalTimeSecs() {
+        return totalTimeSecs;
+    }
+    public void setTotalTimeSecs(double totalTimeSecs) {
+        this.totalTimeSecs = totalTimeSecs;
+    }
     public MemoryInfo getMemory() {
         return memory;
     }

--- a/src/test/resources/build-stats-0.9.0.json
+++ b/src/test/resources/build-stats-0.9.0.json
@@ -1,0 +1,57 @@
+{
+  "resource_usage": {
+    "memory": {
+      "system_total": 67174731776,
+      "peak_rss_bytes": 3348451328
+    },
+    "garbage_collection": {
+      "count": 18,
+      "total_secs": 0.56
+    },
+    "cpu": {
+      "load": 8.253796546702725,
+      "total_cores": 12
+    }
+  },
+  "image_details": {
+    "code_area": {
+      "bytes": 4188016,
+      "compilation_units": 7103
+    },
+    "total_bytes": 11702680,
+    "image_heap": {
+      "bytes": 7249920,
+      "resources": {
+        "bytes": 152415,
+        "count": 5
+      }
+    }
+  },
+  "general_info": {
+    "c_compiler": "gcc (redhat, x86_64, 12.2.1)",
+    "name": "hello",
+    "java_version": "17.0.7-beta+1-202302142331",
+    "garbage_collector": "Serial GC",
+    "graalvm_version": "GraalVM 22.3.2-dev Java 17 Mandrel Distribution"
+  },
+  "analysis_results": {
+    "methods": {
+      "total": 29025,
+      "reflection": 314,
+      "jni": 52,
+      "reachable": 12423
+    },
+    "classes": {
+      "total": 3854,
+      "reflection": 28,
+      "jni": 58,
+      "reachable": 2820
+    },
+    "fields": {
+      "total": 6666,
+      "reflection": 0,
+      "jni": 58,
+      "reachable": 3386
+    }
+  }
+}

--- a/src/test/resources/build-stats-0.9.1.json
+++ b/src/test/resources/build-stats-0.9.1.json
@@ -1,0 +1,67 @@
+{
+  "resource_usage": {
+    "memory": {
+      "system_total": 67174731776,
+      "peak_rss_bytes": 3327168512
+    },
+    "garbage_collection": {
+      "count": 17,
+      "total_secs": 0.414
+    },
+    "cpu": {
+      "load": 8.64321608040201,
+      "total_cores": 12
+    },
+    "total_secs": 22.351071237
+  },
+  "image_details": {
+    "code_area": {
+      "bytes": 4502368,
+      "compilation_units": 7195
+    },
+    "total_bytes": 12123032,
+    "image_heap": {
+      "bytes": 7352320,
+      "objects": {
+        "count": 104902
+      },
+      "resources": {
+        "bytes": 152415,
+        "count": 5
+      }
+    }
+  },
+  "general_info": {
+    "c_compiler": "gcc (redhat, x86_64, 12.2.1)",
+    "name": "testmehello",
+    "java_version": "17.0.7-beta+1-202302142331",
+    "garbage_collector": "Serial GC",
+    "graalvm_version": "GraalVM 23.0.0-dev Java 17.0.7-beta+1-202302142331 Mandrel Distribution"
+  },
+  "analysis_results": {
+    "types": {
+      "total": 3923,
+      "reflection": 862,
+      "jni": 58,
+      "reachable": 2794
+    },
+    "methods": {
+      "total": 28569,
+      "reflection": 337,
+      "jni": 52,
+      "reachable": 12762
+    },
+    "classes": {
+      "total": 3923,
+      "reflection": 862,
+      "jni": 58,
+      "reachable": 2794
+    },
+    "fields": {
+      "total": 6759,
+      "reflection": 0,
+      "jni": 58,
+      "reachable": 3448
+    }
+  }
+}


### PR DESCRIPTION
This allows us to collect build stats with 23.0 and 22.3 graal vm as produced by the 0.9.1 schema of the -H:BuildOutputJSONFile=... option.