### PR TITLE
Delete images by name and date

### DIFF
--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/ImageStats.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/ImageStats.java
@@ -53,6 +53,10 @@ import jakarta.persistence.Table;
 @NamedQuery(name = "ImageStats.distinctImageNamesByKeyword",
         query = "SELECT s.imageName, MAX(s.id) AS id FROM ImageStats s WHERE "
                 + "s.imageName LIKE CONCAT('%',:keyword,'%') GROUP BY s.imageName ORDER BY s.imageName DESC")
+// Delete by image name and date created
+@NamedQuery(name = "ImageStats.deleteByImageNameAndDate",
+        query = "DELETE FROM ImageStats s WHERE s.imageName = :image_name AND "
+                + "s.createdAt > :date_created_oldest AND s.createdAt < :date_created_newest")
 //@formatter:on
 public class ImageStats extends TimestampedEntity {
     @JsonProperty("tag")

--- a/src/test/java/com/redhat/quarkus/mandrel/collector/report/ExperimentTest.java
+++ b/src/test/java/com/redhat/quarkus/mandrel/collector/report/ExperimentTest.java
@@ -102,6 +102,20 @@ public class ExperimentTest {
                     });
             assertEquals("experiment-1-build-perf-karm-graal-1.0.0-runner", searchOne.get(4L));
             assertEquals(1, searchOne.size());
+            final JsonNode deleted0 = given().contentType(ContentType.JSON)
+                    .header("token", token)
+                    .when().delete(StatsTestHelper.BASE_URL + "/image-name/experiment-1-build-perf-karm-graal-1.0.0-runner"
+                            + "?dateOldest=2021-07-05 15:27:54.794&dateNewest=2022-07-05 15:27:54.794")
+                    .body().as(JsonNode.class);
+            // Nothing should satisfy the time test.
+            assertEquals(0, deleted0.get("deleted").asInt());
+            final JsonNode deletedAll = given().contentType(ContentType.JSON)
+                    .header("token", token)
+                    .when().delete(StatsTestHelper.BASE_URL + "/image-name/experiment-1-build-perf-karm-graal-1.0.0-runner"
+                            + "?dateOldest=2021-07-05 15:27:54.794&dateNewest=2999-07-05 15:27:54.794")
+                    .body().as(JsonNode.class);
+            // All records matching the name and fitting the generous time frame must be deleted.
+            assertEquals(2, deletedAll.get("deleted").asInt());
             TestUtil.checkLog();
         } finally {
             if (!ids.isEmpty()) {

--- a/src/test/java/com/redhat/quarkus/mandrel/collector/report/endpoints/ImageStatsResourceTest.java
+++ b/src/test/java/com/redhat/quarkus/mandrel/collector/report/endpoints/ImageStatsResourceTest.java
@@ -227,15 +227,13 @@ public class ImageStatsResourceTest {
                 .get(StatsTestHelper.BASE_URL + "/tags/distinct").body().as(String[].class);
         assertEquals(myTags.length, results.length);
         Set<String> resultsSet = new HashSet<>(Arrays.asList(results));
-        for (int i = 0; i < myTags.length; i++) {
-            assertTrue(resultsSet.contains(myTags[0]), "Expected resultset to contain: " + myTags[i]);
+        for (String myTag : myTags) {
+            assertTrue(resultsSet.contains(myTags[0]), "Expected resultset to contain: " + myTag);
         }
 
         // Delete them again
         List<Long> statIds = new ArrayList<>();
-        stats.stream().forEach(a -> {
-            statIds.add(a.getId());
-        });
+        stats.forEach(a -> statIds.add(a.getId()));
         String imageIdsJson = toJsonString(statIds.toArray(new Long[0]));
         ImageStats[] deletedIds = given().contentType(ContentType.JSON).header("token", token).body(imageIdsJson).when()
                 .delete(StatsTestHelper.BASE_URL).body().as(ImageStats[].class);


### PR DESCRIPTION
I've started producing ephemeral experiment results and it doesn't make sense to me to keep them forever.
I would like to be able to delete such records on demand. To add some safety to UX, I added a mandatory time span that must be defined for record to be deleted, i.e. one would have to mess up the dates to accidentally delete a bunch of records.