### PR TITLE
Introduce RunnerInfo to ImageStats

### DIFF
--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/endpoints/ImageStatsResource.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/endpoints/ImageStatsResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Collector project
+ * Copyright (c) 2022, 2024 Contributors to the Collector project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -22,6 +22,7 @@ package com.redhat.quarkus.mandrel.collector.report.endpoints;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.redhat.quarkus.mandrel.collector.report.model.RunnerInfo;
 import com.redhat.quarkus.mandrel.collector.report.model.ImageStats;
 import com.redhat.quarkus.mandrel.collector.report.model.ImageStatsCollection;
 import com.redhat.quarkus.mandrel.collector.report.model.graal.GraalBuildInfo;
@@ -191,6 +192,21 @@ public class ImageStatsResource {
                     Status.INTERNAL_SERVER_ERROR);
         }
         final ImageStats stat = collection.updateBuildTime(statId, info.getTotalBuildTimeMilis());
+        if (stat == null) {
+            throw new WebApplicationException("Stat with id " + statId + " not found", Status.NOT_FOUND);
+        }
+        return stat;
+    }
+
+    @RolesAllowed("token_write")
+    @POST
+    @Path("update-runner-info/{statId:\\d+}")
+    public ImageStats updateRunnerInfo(@PathParam("statId") Long statId, RunnerInfo info) {
+        if (info == null) {
+            throw new WebApplicationException("RunnerInfo for statId " + statId + " must not be null",
+                    Status.INTERNAL_SERVER_ERROR);
+        }
+        final ImageStats stat = collection.updateRunnerInfo(statId, info);
         if (stat == null) {
             throw new WebApplicationException("Stat with id " + statId + " not found", Status.NOT_FOUND);
         }

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/ImageStats.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/ImageStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Collector project
+ * Copyright (c) 2022, 2024 Contributors to the Collector project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -100,6 +100,11 @@ public class ImageStats extends TimestampedEntity {
     @JoinColumn(name = "reachable_stats_id")
     private ReachableImageStats reachableStats;
 
+    @JsonProperty("runner_info")
+    @OneToOne(optional = true, cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "runner_info_id")
+    private RunnerInfo runnerInfo;
+
     @Id
     @SequenceGenerator(name = "imageStatsSeq", sequenceName = "image_stats_id_seq", allocationSize = 1, initialValue = 1)
     @GeneratedValue(generator = "imageStatsSeq")
@@ -127,6 +132,10 @@ public class ImageStats extends TimestampedEntity {
 
     public void setReachableStats(ReachableImageStats reachableStats) {
         this.reachableStats = reachableStats;
+    }
+
+    public void setRunnerInfo(RunnerInfo runnerInfo) {
+        this.runnerInfo = runnerInfo;
     }
 
     // Hibernate needs this
@@ -172,6 +181,10 @@ public class ImageStats extends TimestampedEntity {
 
     public ReachableImageStats getReachableStats() {
         return reachableStats;
+    }
+
+    public RunnerInfo getRunnerInfo() {
+        return runnerInfo;
     }
 
     public String getGraalVersion() {

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/ImageStatsCollection.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/ImageStatsCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Collector project
+ * Copyright (c) 2022, 2024 Contributors to the Collector project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -122,6 +122,18 @@ public class ImageStatsCollection {
         if (buildTimeMilis != 0) {
             final BuildPerformanceStats perfStats = stat.getResourceStats();
             perfStats.setTotalTimeSeconds(((double) buildTimeMilis) / 1000);
+        }
+        return stat;
+    }
+
+    @Transactional
+    public ImageStats updateRunnerInfo(long id, RunnerInfo info) {
+        final ImageStats stat = getSingle(id);
+        if (stat == null) {
+            return null;
+        }
+        if (info != null) {
+            stat.setRunnerInfo(info);
         }
         return stat;
     }

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/RunnerInfo.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/RunnerInfo.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2024 Contributors to the Collector project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.redhat.quarkus.mandrel.collector.report.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "runner_info")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(discriminatorType = DiscriminatorType.INTEGER, name = "stats_type")
+public class RunnerInfo extends PanacheEntity {
+
+    @JsonProperty
+    private String testVersion;
+    @JsonProperty
+    private String mandrelVersion;
+    @JsonProperty
+    private String jdkVersion;
+    @JsonProperty
+    private String operatingSystem;
+    @JsonProperty
+    private String architecture;
+    @JsonProperty
+    private long memorySize;
+    @JsonProperty
+    private String description;
+
+    public String getTestVersion() {
+        return testVersion;
+    }
+
+    public void setTestVersion(String testVersion) {
+        this.testVersion = testVersion;
+    }
+
+    public String getMandrelVersion() {
+        return mandrelVersion;
+    }
+
+    public void setMandrelVersion(String mandrelVersion) {
+        this.mandrelVersion = mandrelVersion;
+    }
+
+    public String getJdkVersion() {
+        return jdkVersion;
+    }
+
+    public void setJdkVersion(String jdkVersion) {
+        this.jdkVersion = jdkVersion;
+    }
+
+    public String getOperatingSystem() {
+        return operatingSystem;
+    }
+
+    public void setOperatingSystem(String operatingSystem) {
+        this.operatingSystem = operatingSystem;
+    }
+
+    public String getArchitecture() {
+        return architecture;
+    }
+
+    public void setArchitecture(String architecture) {
+        this.architecture = architecture;
+    }
+
+    public long getMemorySize() {
+        return memorySize;
+    }
+
+    public void setMemorySize(long memorySize) {
+        this.memorySize = memorySize;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/src/test/java/com/redhat/quarkus/mandrel/collector/TestUtil.java
+++ b/src/test/java/com/redhat/quarkus/mandrel/collector/TestUtil.java
@@ -63,6 +63,7 @@ public class TestUtil {
             Pattern.compile(".*Unknown SEQUENCE: 'quarkus.simple_time_and_size_SEQ'.*"),
             Pattern.compile(".*Unknown SEQUENCE: 'quarkus.token_SEQ'.*"),
             Pattern.compile(".*Unknown SEQUENCE: 'quarkus.user_SEQ'.*"),
+            Pattern.compile(".*Unknown SEQUENCE: 'quarkus.runner_info_SEQ'.*"),
             // Quarkus deprecated, we need to deal wit it:
             Pattern.compile(".*'quarkus.http.auth.form.redirect-after-login' config property is deprecated.*"),
     };

--- a/src/test/java/com/redhat/quarkus/mandrel/collector/report/endpoints/ImageStatsResourceTest.java
+++ b/src/test/java/com/redhat/quarkus/mandrel/collector/report/endpoints/ImageStatsResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Collector project
+ * Copyright (c) 2022, 2024 Contributors to the Collector project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -23,6 +23,7 @@ package com.redhat.quarkus.mandrel.collector.report.endpoints;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.quarkus.mandrel.collector.TestUtil;
 import com.redhat.quarkus.mandrel.collector.report.endpoints.StatsTestHelper.Mode;
+import com.redhat.quarkus.mandrel.collector.report.model.RunnerInfo;
 import com.redhat.quarkus.mandrel.collector.report.model.BuildPerformanceStats;
 import com.redhat.quarkus.mandrel.collector.report.model.ImageSizeStats;
 import com.redhat.quarkus.mandrel.collector.report.model.ImageStats;
@@ -297,6 +298,8 @@ public class ImageStatsResourceTest {
     private ImageStats createImageStat(String name, String tag) {
         ImageStats imageStats = new ImageStats(name);
         imageStats.setGraalVersion("GraalVM 21.3 (Java 17) Mandrel Distribution");
+        RunnerInfo runnerInfo = new RunnerInfo();
+        imageStats.setRunnerInfo(runnerInfo);
         if (tag != null) {
             imageStats.setTag(tag);
         }


### PR DESCRIPTION
This new optional entry is meant to be used for additional information
related to the runner used to perform the testing that generated the
gathered image statistics.

Closes https://github.com/Karm/collector/issues/22
