### PR TITLE
Normalizes attributes names, adds Q version

### DIFF
--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/endpoints/ImageStatsResource.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/endpoints/ImageStatsResource.java
@@ -27,6 +27,7 @@ import com.redhat.quarkus.mandrel.collector.report.model.ImageStats;
 import com.redhat.quarkus.mandrel.collector.report.model.ImageStatsCollection;
 import com.redhat.quarkus.mandrel.collector.report.model.graal.GraalBuildInfo;
 import io.quarkus.runtime.util.StringUtil;
+import io.smallrye.common.constraint.NotNull;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -173,7 +174,7 @@ public class ImageStatsResource {
 
     @RolesAllowed("token_write")
     @POST
-    public ImageStats add(ImageStats stat, @QueryParam("t") String tag) {
+    public ImageStats add(@NotNull ImageStats stat, @QueryParam("t") String tag) {
         if (stat.getId() > 0) {
             throw new WebApplicationException("Id was invalidly set on request.", 422);
         }

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/RunnerInfo.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/RunnerInfo.java
@@ -20,7 +20,8 @@
 
 package com.redhat.quarkus.mandrel.collector.report.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
 import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.DiscriminatorType;
@@ -29,25 +30,21 @@ import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Entity
 @Table(name = "runner_info")
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(discriminatorType = DiscriminatorType.INTEGER, name = "stats_type")
 public class RunnerInfo extends PanacheEntity {
 
-    @JsonProperty
     private String testVersion;
-    @JsonProperty
     private String mandrelVersion;
-    @JsonProperty
+    private String quarkusVersion;
     private String jdkVersion;
-    @JsonProperty
     private String operatingSystem;
-    @JsonProperty
     private String architecture;
-    @JsonProperty
     private long memorySizeBytes;
-    @JsonProperty
+    private long memoryAvailableBytes;
     private String description;
 
     public String getTestVersion() {
@@ -64,6 +61,14 @@ public class RunnerInfo extends PanacheEntity {
 
     public void setMandrelVersion(String mandrelVersion) {
         this.mandrelVersion = mandrelVersion;
+    }
+
+    public String getQuarkusVersion() {
+        return quarkusVersion;
+    }
+
+    public void setQuarkusVersion(String quarkusVersion) {
+        this.quarkusVersion = quarkusVersion;
     }
 
     public String getJdkVersion() {
@@ -96,6 +101,14 @@ public class RunnerInfo extends PanacheEntity {
 
     public void setMemorySizeBytes(long memorySizeBytes) {
         this.memorySizeBytes = memorySizeBytes;
+    }
+
+    public long getMemoryAvailableBytes() {
+        return memoryAvailableBytes;
+    }
+
+    public void setMemoryAvailableBytes(long memoryAvailableBytes) {
+        this.memoryAvailableBytes = memoryAvailableBytes;
     }
 
     public String getDescription() {

--- a/src/test/java/com/redhat/quarkus/mandrel/collector/report/endpoints/GraalImageStatsResourceTest.java
+++ b/src/test/java/com/redhat/quarkus/mandrel/collector/report/endpoints/GraalImageStatsResourceTest.java
@@ -20,27 +20,25 @@
 
 package com.redhat.quarkus.mandrel.collector.report.endpoints;
 
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import com.redhat.quarkus.mandrel.collector.TestUtil;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-
 import com.redhat.quarkus.mandrel.collector.report.endpoints.StatsTestHelper.Mode;
 import com.redhat.quarkus.mandrel.collector.report.model.ImageStats;
-
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.parsing.Parser;
 import io.restassured.response.ResponseBody;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
 public class GraalImageStatsResourceTest {
@@ -54,7 +52,7 @@ public class GraalImageStatsResourceTest {
 
     @Test
     public void testImport() throws Exception {
-        String json = createGraalJSON();
+        String json = StatsTestHelper.getStatString("22.3/c.json");
         String token = StatsTestHelper.login(Mode.READ_WRITE);
         ResponseBody<?> body = given().contentType(ContentType.JSON).header("token", token).body(json).when()
                 .post(StatsTestHelper.BASE_URL + "/import").body();
@@ -74,7 +72,7 @@ public class GraalImageStatsResourceTest {
 
     @Test
     public void testImportAndRunnerInfoUpdate() throws Exception {
-        String json = createGraalJSON();
+        String json = StatsTestHelper.getStatString("22.3/c.json");
         String token = StatsTestHelper.login(Mode.READ_WRITE);
         ResponseBody<?> body = given().contentType(ContentType.JSON).header("token", token).body(json).when()
                 .post(StatsTestHelper.BASE_URL + "/import").body();
@@ -88,7 +86,7 @@ public class GraalImageStatsResourceTest {
         idsToDelete.add(originalId);
 
         // Now add some runner info
-        json = createRunnerJSON();
+        json = StatsTestHelper.getStatString("22.3/c-runner.json");
         body = given().contentType(ContentType.JSON).header("token", token).body(json).when()
                 .post(StatsTestHelper.BASE_URL + "/update-runner-info/" + originalId).body();
         result = body.as(ImageStats.class);
@@ -96,6 +94,42 @@ public class GraalImageStatsResourceTest {
         assertEquals(result.getId(), originalId);
         assertEquals("foo-bar", result.getImageName());
         assertEquals("Github Runner 2.315.0", result.getRunnerInfo().getDescription());
+        assertEquals(274877906944L, result.getRunnerInfo().getMemorySizeBytes());
+
+        // Ensure we can listOne the result
+        given().contentType(ContentType.JSON).header("token", token).when()
+                .get(StatsTestHelper.BASE_URL + "/" + originalId).then().statusCode(200)
+                .body(containsString(result.getImageName()),
+                        containsString(result.getGraalVersion()),
+                        containsString(result.getRunnerInfo().getDescription()));
+        TestUtil.checkLog();
+    }
+
+    @Test
+    public void testImportAndRunnerM24InfoUpdate() throws Exception {
+        String json = StatsTestHelper.getStatString("24.0/quarkus.json");
+        String token = StatsTestHelper.login(Mode.READ_WRITE);
+        ResponseBody<?> body = given().contentType(ContentType.JSON).header("token", token).body(json).when()
+                .post(StatsTestHelper.BASE_URL + "/import").body();
+        ImageStats result = body.as(ImageStats.class);
+
+        long originalId = result.getId();
+        assertTrue(originalId > 0);
+        assertEquals("experiment-1-build-perf-karm-graal-1.0.0-runner", result.getImageName());
+        assertEquals("Mandrel-24.0.0.0-dev18889be7190", result.getGraalVersion());
+
+        idsToDelete.add(originalId);
+
+        // Now add some runner info
+        json = StatsTestHelper.getStatString("24.0/c-runner-missing-stuff.json");
+        body = given().contentType(ContentType.JSON).header("token", token).body(json).when()
+                .post(StatsTestHelper.BASE_URL + "/update-runner-info/" + originalId).body();
+        result = body.as(ImageStats.class);
+
+        assertEquals(result.getId(), originalId);
+        assertEquals("experiment-1-build-perf-karm-graal-1.0.0-runner", result.getImageName());
+        assertEquals("Github Runner 666", result.getRunnerInfo().getDescription());
+        assertEquals("3.8.4.Final", result.getRunnerInfo().getQuarkusVersion());
         assertEquals(274877906944L, result.getRunnerInfo().getMemorySizeBytes());
 
         // Ensure we can listOne the result
@@ -116,84 +150,5 @@ public class GraalImageStatsResourceTest {
                     .delete(StatsTestHelper.BASE_URL + "/" + id).then().statusCode(200);
         }
         idsToDelete.clear();
-    }
-
-    private String createGraalJSON() {
-        // @formatter:off
-        return "{\n"
-                + "  \"resource_usage\": {\n"
-                + "    \"memory\": {\n"
-                + "      \"system_total\": 33260355584,\n"
-                + "      \"peak_rss_bytes\": 3127443456\n"
-                + "    },\n"
-                + "    \"garbage_collection\": {\n"
-                + "      \"count\": 20,\n"
-                + "      \"total_secs\": 1.097\n"
-                + "    },\n"
-                + "    \"cpu\": {\n"
-                + "      \"load\": 6.307451297470753,\n"
-                + "      \"total_cores\": 8\n"
-                + "    }\n"
-                + "  },\n"
-                + "  \"image_details\": {\n"
-                + "    \"debug_info\": {\n"
-                + "      \"bytes\": 7694974\n"
-                + "    },\n"
-                + "    \"code_area\": {\n"
-                + "      \"bytes\": 4181808,\n"
-                + "      \"compilation_units\": 7040\n"
-                + "    },\n"
-                + "    \"total_bytes\": 20157545,\n"
-                + "    \"image_heap\": {\n"
-                + "      \"bytes\": 7233536,\n"
-                + "      \"resources\": {\n"
-                + "        \"bytes\": 142884,\n"
-                + "        \"count\": 5\n"
-                + "      }\n"
-                + "    }\n"
-                + "  },\n"
-                + "  \"general_info\": {\n"
-                + "    \"c_compiler\": \"gcc (redhat, x86_64, 11.3.1)\",\n"
-                + "    \"name\": \"foo-bar\",\n"
-                + "    \"java_version\": null,\n"
-                + "    \"garbage_collector\": \"Serial GC\",\n"
-                + "    \"graalvm_version\": \"GraalVM 22.3.0-dev Java 11 Mandrel Distribution\"\n"
-                + "  },\n"
-                + "  \"analysis_results\": {\n"
-                + "    \"methods\": {\n"
-                + "      \"total\": 27123,\n"
-                + "      \"reflection\": 267,\n"
-                + "      \"jni\": 52,\n"
-                + "      \"reachable\": 12255\n"
-                + "    },\n"
-                + "    \"classes\": {\n"
-                + "      \"total\": 3725,\n"
-                + "      \"reflection\": 27,\n"
-                + "      \"jni\": 58,\n"
-                + "      \"reachable\": 2709\n"
-                + "    },\n"
-                + "    \"fields\": {\n"
-                + "      \"total\": 6388,\n"
-                + "      \"reflection\": 0,\n"
-                + "      \"jni\": -1,\n"
-                + "      \"reachable\": 3430\n"
-                + "    }\n"
-                + "  }\n"
-                + "}";
-        // @formatter:on
-    }
-
-    // We intentionally leave out the "operatingSystem" entry to test how missing entries are handled
-    private String createRunnerJSON() {
-        return """
-                 {
-                   "testVersion": "1.0.0",
-                   "mandrelVersion": "22.3.0",
-                   "jdkVersion": "17.0.7",
-                   "architecture": "x86_64",
-                   "memorySizeBytes": 274877906944,
-                   "description" : "Github Runner 2.315.0"
-                 }
-                """;
     }
 }

--- a/src/test/java/com/redhat/quarkus/mandrel/collector/report/endpoints/StatsTestHelper.java
+++ b/src/test/java/com/redhat/quarkus/mandrel/collector/report/endpoints/StatsTestHelper.java
@@ -32,6 +32,7 @@ import org.apache.http.HttpStatus;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
@@ -103,7 +104,9 @@ public class StatsTestHelper {
 
     public static String getStatString(String name) {
         try (InputStream is = StatsTestHelper.class.getResourceAsStream("/" + name)) {
-            return new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            return new String(Objects.requireNonNull(is).readAllBytes(), StandardCharsets.UTF_8)
+                    // Eat "comments" in the JSON
+                    .replaceAll("(?m)^#.*$", "");
         } catch (IOException e) {
             throw new AssertionError("Error reading file: " + name, e);
         }

--- a/src/test/resources/22.3/c-runner.json
+++ b/src/test/resources/22.3/c-runner.json
@@ -1,0 +1,11 @@
+{
+  "test_version": "1.0.0",
+  "mandrel_version": "22.3.0",
+  "quarkus_version": "2.13.3.Final",
+  "jdk_version": "17.0.7",
+  "operating_system": "Linux",
+  "architecture": "x86_64",
+  "memory_size_bytes": 274877906944,
+  "memory_available_bytes": 174811906921,
+  "description": "Github Runner 2.315.0"
+}

--- a/src/test/resources/22.3/c.json
+++ b/src/test/resources/22.3/c.json
@@ -1,0 +1,60 @@
+{
+  "resource_usage": {
+    "memory": {
+      "system_total": 33260355584,
+      "peak_rss_bytes": 3127443456
+    },
+    "garbage_collection": {
+      "count": 20,
+      "total_secs": 1.097
+    },
+    "cpu": {
+      "load": 6.307451297470753,
+      "total_cores": 8
+    }
+  },
+  "image_details": {
+    "debug_info": {
+      "bytes": 7694974
+    },
+    "code_area": {
+      "bytes": 4181808,
+      "compilation_units": 7040
+    },
+    "total_bytes": 20157545,
+    "image_heap": {
+      "bytes": 7233536,
+      "resources": {
+        "bytes": 142884,
+        "count": 5
+      }
+    }
+  },
+  "general_info": {
+    "c_compiler": "gcc (redhat, x86_64, 11.3.1)",
+    "name": "foo-bar",
+    "java_version": null,
+    "garbage_collector": "Serial GC",
+    "graalvm_version": "GraalVM 22.3.0-dev Java 11 Mandrel Distribution"
+  },
+  "analysis_results": {
+    "methods": {
+      "total": 27123,
+      "reflection": 267,
+      "jni": 52,
+      "reachable": 12255
+    },
+    "classes": {
+      "total": 3725,
+      "reflection": 27,
+      "jni": 58,
+      "reachable": 2709
+    },
+    "fields": {
+      "total": 6388,
+      "reflection": 0,
+      "jni": -1,
+      "reachable": 3430
+    }
+  }
+}

--- a/src/test/resources/23.1/quarkus.json
+++ b/src/test/resources/23.1/quarkus.json
@@ -1,1 +1,75 @@
-{"resource_usage":{"memory":{"system_total":66847477760,"peak_rss_bytes":6541160448},"garbage_collection":{"count":131,"total_secs":12.114,"max_heap":7700742144},"cpu":{"load":10.962218425966391,"parallelism":16,"total_cores":16},"total_secs":125.28958178799999},"image_details":{"code_area":{"bytes":51898144,"compilation_units":82642},"total_bytes":108374600,"image_heap":{"bytes":56053760,"objects":{"count":579071},"resources":{"bytes":251064,"count":91}}},"general_info":{"c_compiler":"gcc (redhat, x86_64, 11.4.1)","name":"experiment-1-build-perf-karm-graal-1.0.0-runner","java_version":"21.0.1+12-LTS","garbage_collector":"Serial GC","graal_compiler":{"march":"x86-64-v3","optimization_level":"2"},"vendor_version":"Mandrel-23.1.1.0-Final","graalvm_version":"Mandrel-23.1.1.0-Final"},"analysis_results":{"types":{"total":29762,"reflection":7827,"jni":61,"reachable":26966},"methods":{"foreign_downcalls":-1,"total":228109,"reflection":5698,"jni":55,"reachable":128581},"classes":{"total":29762,"reflection":7827,"jni":61,"reachable":26966},"fields":{"total":58215,"reflection":586,"jni":59,"reachable":37670}}}
+{
+  "resource_usage": {
+    "memory": {
+      "system_total": 66847477760,
+      "peak_rss_bytes": 6541160448
+    },
+    "garbage_collection": {
+      "count": 131,
+      "total_secs": 12.114,
+      "max_heap": 7700742144
+    },
+    "cpu": {
+      "load": 10.962218425966391,
+      "parallelism": 16,
+      "total_cores": 16
+    },
+    "total_secs": 125.28958178799999
+  },
+  "image_details": {
+    "code_area": {
+      "bytes": 51898144,
+      "compilation_units": 82642
+    },
+    "total_bytes": 108374600,
+    "image_heap": {
+      "bytes": 56053760,
+      "objects": {
+        "count": 579071
+      },
+      "resources": {
+        "bytes": 251064,
+        "count": 91
+      }
+    }
+  },
+  "general_info": {
+    "c_compiler": "gcc (redhat, x86_64, 11.4.1)",
+    "name": "experiment-1-build-perf-karm-graal-1.0.0-runner",
+    "java_version": "21.0.1+12-LTS",
+    "garbage_collector": "Serial GC",
+    "graal_compiler": {
+      "march": "x86-64-v3",
+      "optimization_level": "2"
+    },
+    "vendor_version": "Mandrel-23.1.1.0-Final",
+    "graalvm_version": "Mandrel-23.1.1.0-Final"
+  },
+  "analysis_results": {
+    "types": {
+      "total": 29762,
+      "reflection": 7827,
+      "jni": 61,
+      "reachable": 26966
+    },
+    "methods": {
+      "foreign_downcalls": -1,
+      "total": 228109,
+      "reflection": 5698,
+      "jni": 55,
+      "reachable": 128581
+    },
+    "classes": {
+      "total": 29762,
+      "reflection": 7827,
+      "jni": 61,
+      "reachable": 26966
+    },
+    "fields": {
+      "total": 58215,
+      "reflection": 586,
+      "jni": 59,
+      "reachable": 37670
+    }
+  }
+}

--- a/src/test/resources/24.0/c-runner-missing-stuff.json
+++ b/src/test/resources/24.0/c-runner-missing-stuff.json
@@ -1,0 +1,12 @@
+# We drop # prefied "comments" like this from the string.
+{
+  "test_version": "1.0.0",
+  "mandrel_version": "24.0.0",
+  "quarkus_version": "3.8.4.Final",
+  "jdk_version": "17.0.7",
+#  "operating_system": "Linux",
+#  "architecture": "x86_64",
+  "memory_size_bytes": 274877906944,
+  "memory_available_bytes": 174811906921,
+  "description": "Github Runner 666"
+}

--- a/src/test/resources/24.0/quarkus.json
+++ b/src/test/resources/24.0/quarkus.json
@@ -1,1 +1,75 @@
-{"resource_usage":{"memory":{"system_total":66847477760,"peak_rss_bytes":7943794688},"garbage_collection":{"count":107,"total_secs":10.565,"max_heap":28445245440},"cpu":{"load":11.254874158099966,"parallelism":16,"total_cores":16},"total_secs":132.016879377},"image_details":{"code_area":{"bytes":51297744,"compilation_units":83004},"total_bytes":108253200,"image_heap":{"bytes":56528896,"objects":{"count":582250},"resources":{"bytes":251104,"count":100}}},"general_info":{"c_compiler":"gcc (redhat, x86_64, 11.4.1)","name":"experiment-1-build-perf-karm-graal-1.0.0-runner","java_version":"22-beta+33-ea","garbage_collector":"Serial GC","graal_compiler":{"march":"x86-64-v3","optimization_level":"2"},"vendor_version":"Mandrel-24.0.0.0-dev18889be7190","graalvm_version":"Mandrel-24.0.0.0-dev18889be7190"},"analysis_results":{"types":{"total":29893,"reflection":7878,"jni":61,"reachable":26982},"methods":{"foreign_downcalls":-1,"total":228378,"reflection":5693,"jni":55,"reachable":128872},"classes":{"total":29893,"reflection":7878,"jni":61,"reachable":26982},"fields":{"total":64697,"reflection":593,"jni":61,"reachable":37635}}}
+{
+  "resource_usage": {
+    "memory": {
+      "system_total": 66847477760,
+      "peak_rss_bytes": 7943794688
+    },
+    "garbage_collection": {
+      "count": 107,
+      "total_secs": 10.565,
+      "max_heap": 28445245440
+    },
+    "cpu": {
+      "load": 11.254874158099966,
+      "parallelism": 16,
+      "total_cores": 16
+    },
+    "total_secs": 132.016879377
+  },
+  "image_details": {
+    "code_area": {
+      "bytes": 51297744,
+      "compilation_units": 83004
+    },
+    "total_bytes": 108253200,
+    "image_heap": {
+      "bytes": 56528896,
+      "objects": {
+        "count": 582250
+      },
+      "resources": {
+        "bytes": 251104,
+        "count": 100
+      }
+    }
+  },
+  "general_info": {
+    "c_compiler": "gcc (redhat, x86_64, 11.4.1)",
+    "name": "experiment-1-build-perf-karm-graal-1.0.0-runner",
+    "java_version": "22-beta+33-ea",
+    "garbage_collector": "Serial GC",
+    "graal_compiler": {
+      "march": "x86-64-v3",
+      "optimization_level": "2"
+    },
+    "vendor_version": "Mandrel-24.0.0.0-dev18889be7190",
+    "graalvm_version": "Mandrel-24.0.0.0-dev18889be7190"
+  },
+  "analysis_results": {
+    "types": {
+      "total": 29893,
+      "reflection": 7878,
+      "jni": 61,
+      "reachable": 26982
+    },
+    "methods": {
+      "foreign_downcalls": -1,
+      "total": 228378,
+      "reflection": 5693,
+      "jni": 55,
+      "reachable": 128872
+    },
+    "classes": {
+      "total": 29893,
+      "reflection": 7878,
+      "jni": 61,
+      "reachable": 26982
+    },
+    "fields": {
+      "total": 64697,
+      "reflection": 593,
+      "jni": 61,
+      "reachable": 37635
+    }
+  }
+}


### PR DESCRIPTION
Adds `memoryAvailableBytes` and `quarkusVersion`, normalizes column names and Json serialization to what we have elsewhere, snake_case.   Note: Wasn't this global with the Q 2.x?