### PR TITLE
Add Swagger UI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,10 @@
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-openapi</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -108,3 +108,6 @@ tokens.error.permission.match={"error":"Permission is expected to match regexp %
 tokens.success.created={"token":"%s","message":"Save the token safely. \
 This is the only time it could be displayed."}
 tokens.success.deleted={"message":"Deleted tokens: %d"}
+
+# Swagger UI
+quarkus.swagger-ui.always-include=true


### PR DESCRIPTION
The goal of this is to make it easier to explore the API. It uses the
default path which is http://<hostname>/q/swagger-ui
