### PR TITLE
RunnerInfo lookup and mapping

### DIFF
--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/endpoints/GraalImageStatsResource.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/endpoints/GraalImageStatsResource.java
@@ -29,15 +29,12 @@ public class GraalImageStatsResource {
     @RolesAllowed("token_write")
     @Path("import")
     @POST
-    public ImageStats importStat(GraalStats importStat, @QueryParam("t") String tag, @QueryParam("rid") Long runnerInfoId)
+    public ImageStats importStat(GraalStats importStat, @QueryParam("t") String tag, @QueryParam("runnerid") Long runnerInfoId)
             throws WebApplicationException {
         if (importStat == null) {
-            throw new WebApplicationException("GraalStats must not be null", Status.INTERNAL_SERVER_ERROR);
+            throw new WebApplicationException("GraalStats must not be null", Status.BAD_REQUEST);
         }
         final ImageStats stat = ADAPTER.adapt(importStat);
-        if (tag != null) {
-            stat.setTag(tag);
-        }
-        return collection.add(stat, runnerInfoId);
+        return collection.add(stat, tag, runnerInfoId);
     }
 }

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/endpoints/GraalImageStatsResource.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/endpoints/GraalImageStatsResource.java
@@ -6,6 +6,7 @@ import com.redhat.quarkus.mandrel.collector.report.model.ImageStatsCollection;
 import com.redhat.quarkus.mandrel.collector.report.model.graal.GraalStats;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -21,16 +22,15 @@ import jakarta.ws.rs.core.Response.Status;
 public class GraalImageStatsResource {
 
     private static final StatsAdapter ADAPTER = new StatsAdapter();
-    private final ImageStatsCollection collection;
 
-    public GraalImageStatsResource(ImageStatsCollection collection) {
-        this.collection = collection;
-    }
+    @Inject
+    ImageStatsCollection collection;
 
     @RolesAllowed("token_write")
     @Path("import")
     @POST
-    public ImageStats importStat(GraalStats importStat, @QueryParam("t") String tag) throws WebApplicationException {
+    public ImageStats importStat(GraalStats importStat, @QueryParam("t") String tag, @QueryParam("rid") Long runnerInfoId)
+            throws WebApplicationException {
         if (importStat == null) {
             throw new WebApplicationException("GraalStats must not be null", Status.INTERNAL_SERVER_ERROR);
         }
@@ -38,6 +38,6 @@ public class GraalImageStatsResource {
         if (tag != null) {
             stat.setTag(tag);
         }
-        return collection.add(stat);
+        return collection.add(stat, runnerInfoId);
     }
 }

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/endpoints/ImageStatsResource.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/endpoints/ImageStatsResource.java
@@ -27,7 +27,6 @@ import com.redhat.quarkus.mandrel.collector.report.model.ImageStatsCollection;
 import com.redhat.quarkus.mandrel.collector.report.model.RunnerInfo;
 import com.redhat.quarkus.mandrel.collector.report.model.graal.GraalBuildInfo;
 import io.quarkus.runtime.util.StringUtil;
-import io.smallrye.common.constraint.NotNull;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -52,10 +51,19 @@ import org.jboss.logging.Logger;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
+import static com.redhat.quarkus.mandrel.collector.report.model.ImageStats.SearchableRunnerInfo.DESCRIPTION;
+import static com.redhat.quarkus.mandrel.collector.report.model.ImageStats.SearchableRunnerInfo.GRAALVM_VERSION;
+import static com.redhat.quarkus.mandrel.collector.report.model.ImageStats.SearchableRunnerInfo.ID;
+import static com.redhat.quarkus.mandrel.collector.report.model.ImageStats.SearchableRunnerInfo.JDK_VERSION;
+import static com.redhat.quarkus.mandrel.collector.report.model.ImageStats.SearchableRunnerInfo.QUARKUS_VERSION;
+import static com.redhat.quarkus.mandrel.collector.report.model.ImageStats.SearchableRunnerInfo.TEST_VERSION;
+import static com.redhat.quarkus.mandrel.collector.report.model.ImageStats.SearchableRunnerInfo.TRIGGERED_BY;
 import static com.redhat.quarkus.mandrel.collector.report.model.ImageStatsCollection.CREATED_DATE_FORMAT;
 import static com.redhat.quarkus.mandrel.collector.report.model.ImageStatsCollection.CREATED_DATE_FORMATTER;
 
@@ -91,21 +99,35 @@ public class ImageStatsResource {
         return collection.getAllByTag(tag);
     }
 
-    // TODO: Not sure about the API, we need some consistency...
     @RolesAllowed("token_read")
     @GET
-    @Path("lookup")
-    public ImageStats[] getByGhPR(@QueryParam("ghPR") String ghPR, @QueryParam("rid") Long runnerInfoId) {
-        if (ghPR != null && runnerInfoId != null) {
-            throw new WebApplicationException("Only one of ghPR or rid can be set at the moment.", Status.BAD_REQUEST);
+    @Path("lookup/runner-info/{column}")
+    public ImageStats[] lookupTest(@QueryParam("key") String key, @QueryParam("wildcard") boolean wildcard,
+            @PathParam("column") String column) {
+
+        if (key == null) {
+            throw new WebApplicationException("key must not be null", Status.BAD_REQUEST);
         }
-        if (runnerInfoId != null) {
-            return collection.getAllByRunnerInfo(runnerInfoId);
+        if (TEST_VERSION.column.equals(column)) {
+            return collection.lookup(key, TEST_VERSION, wildcard);
+        } else if (GRAALVM_VERSION.column.equals(column)) {
+            return collection.lookup(key, GRAALVM_VERSION, wildcard);
+        } else if (QUARKUS_VERSION.column.equals(column)) {
+            return collection.lookup(key, QUARKUS_VERSION, wildcard);
+        } else if (JDK_VERSION.column.equals(column)) {
+            return collection.lookup(key, JDK_VERSION, wildcard);
+        } else if (DESCRIPTION.column.equals(column)) {
+            return collection.lookup(key, DESCRIPTION, wildcard);
+        } else if (TRIGGERED_BY.column.equals(column)) {
+            return collection.lookup(key, TRIGGERED_BY, wildcard);
+        } else if (ID.column.equals(column)) {
+            return collection.lookup(key, ID, false);
         }
-        if (ghPR != null) {
-            return collection.getAllByGhPR(ghPR);
-        }
-        throw new WebApplicationException("Either ghPR or rid must be set.", Status.BAD_REQUEST);
+        throw new WebApplicationException("column must be one of " +
+                Arrays.stream(ImageStats.SearchableRunnerInfo.values())
+                        .map(info -> info.column)
+                        .collect(Collectors.joining(", ")),
+                Status.BAD_REQUEST);
     }
 
     @RolesAllowed("token_read")
@@ -190,14 +212,15 @@ public class ImageStatsResource {
 
     @RolesAllowed("token_write")
     @POST
-    public ImageStats add(@NotNull ImageStats stat, @QueryParam("t") String tag, @QueryParam("rid") Long runnerInfoId) {
+    public ImageStats add(ImageStats stat, @QueryParam("t") String tag, @QueryParam("runnerid") Long runnerInfoId) {
+        if (stat == null) {
+            throw new WebApplicationException("ImageStats must not be null",
+                    Status.BAD_REQUEST);
+        }
         if (stat.getId() > 0) {
             throw new WebApplicationException("Id was invalidly set on request.", 422);
         }
-        if (tag != null) {
-            stat.setTag(tag);
-        }
-        return collection.add(stat, runnerInfoId);
+        return collection.add(stat, tag, runnerInfoId);
     }
 
     @RolesAllowed("token_write")
@@ -206,7 +229,7 @@ public class ImageStatsResource {
     public ImageStats updateBuildTime(@PathParam("statId") Long statId, GraalBuildInfo info) {
         if (info == null) {
             throw new WebApplicationException("GraalBuildInfo for statId " + statId + " must not be null",
-                    Status.INTERNAL_SERVER_ERROR);
+                    Status.BAD_REQUEST);
         }
         final ImageStats stat = collection.updateBuildTime(statId, info.getTotalBuildTimeMilis());
         if (stat == null) {
@@ -221,7 +244,7 @@ public class ImageStatsResource {
     public ImageStats updateRunnerInfo(@PathParam("statId") Long statId, RunnerInfo info) {
         if (info == null) {
             throw new WebApplicationException("RunnerInfo for statId " + statId + " must not be null",
-                    Status.INTERNAL_SERVER_ERROR);
+                    Status.BAD_REQUEST);
         }
         final ImageStats stat = collection.updateRunnerInfo(statId, info);
         if (stat == null) {
@@ -233,20 +256,23 @@ public class ImageStatsResource {
     @RolesAllowed("token_write")
     @POST
     @Path("runner-info")
-    public RunnerInfo createRunnerInfo(@NotNull RunnerInfo info) {
+    public RunnerInfo createRunnerInfo(RunnerInfo info) {
+        if (info == null) {
+            throw new WebApplicationException("RunnerInfo must not be null", Status.BAD_REQUEST);
+        }
         return collection.add(info);
     }
 
     @RolesAllowed("token_write")
     @DELETE
-    @Path("runner-info/{runnerId}")
+    @Path("runner-info/{runnerId:\\d+}")
     public RunnerInfo deleteRunnerInfo(@PathParam("runnerId") Long runnerId) {
         return collection.deleteRunnerInfo(runnerId);
     }
 
     @RolesAllowed("token_write")
     @DELETE
-    @Path("{statId}")
+    @Path("{statId:\\d+}")
     public ImageStats delete(@PathParam("statId") Long statId) {
         return collection.deleteOne(statId);
     }
@@ -254,6 +280,9 @@ public class ImageStatsResource {
     @RolesAllowed("token_write")
     @DELETE
     public ImageStats[] deleteMany(Long[] ids) {
+        if (ids == null) {
+            throw new WebApplicationException("ids must not be null", Status.BAD_REQUEST);
+        }
         return collection.deleteMany(ids);
     }
 
@@ -300,7 +329,7 @@ public class ImageStatsResource {
                 code = ((WebApplicationException) exception).getResponse().getStatus();
             }
 
-            ObjectNode exceptionJson = objectMapper.createObjectNode();
+            final ObjectNode exceptionJson = objectMapper.createObjectNode();
             exceptionJson.put("exceptionType", exception.getClass().getName());
             exceptionJson.put("code", code);
 
@@ -310,6 +339,5 @@ public class ImageStatsResource {
 
             return Response.status(code).entity(exceptionJson).build();
         }
-
     }
 }

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/ImageStats.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/ImageStats.java
@@ -58,13 +58,6 @@ import jakarta.persistence.Table;
 @NamedQuery(name = "ImageStats.deleteByImageNameAndDate",
         query = "DELETE FROM ImageStats s WHERE s.imageName = :image_name AND "
                 + "s.createdAt > :date_created_oldest AND s.createdAt < :date_created_newest")
-/*
- * RunnerInfo lookup
- */
-@NamedQuery(name = "ImageStats.findByGhPR",
-        query = "SELECT s FROM ImageStats s WHERE s.runnerInfo.ghPR = :ghPR ORDER BY s.imageName")
-@NamedQuery(name = "ImageStats.findByRunnerInfoId",
-        query = "SELECT s FROM ImageStats s WHERE s.runnerInfo.id = :runnerInfoId ORDER BY s.imageName")
 //@formatter:on
 public class ImageStats extends TimestampedEntity {
     @JsonProperty("tag")
@@ -117,6 +110,22 @@ public class ImageStats extends TimestampedEntity {
     @SequenceGenerator(name = "imageStatsSeq", sequenceName = "image_stats_id_seq", allocationSize = 1, initialValue = 1)
     @GeneratedValue(generator = "imageStatsSeq")
     private long id;
+
+    public enum SearchableRunnerInfo {
+        ID("id"),
+        TEST_VERSION("testVersion"),
+        GRAALVM_VERSION("graalvmVersion"),
+        QUARKUS_VERSION("quarkusVersion"),
+        JDK_VERSION("jdkVersion"),
+        DESCRIPTION("description"),
+        TRIGGERED_BY("triggeredBy");
+
+        public final String column;
+
+        SearchableRunnerInfo(String column) {
+            this.column = column;
+        }
+    }
 
     public ImageStats(String name) {
         this.imageName = name;

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/ImageStats.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/ImageStats.java
@@ -27,6 +27,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.SequenceGenerator;
@@ -57,6 +58,13 @@ import jakarta.persistence.Table;
 @NamedQuery(name = "ImageStats.deleteByImageNameAndDate",
         query = "DELETE FROM ImageStats s WHERE s.imageName = :image_name AND "
                 + "s.createdAt > :date_created_oldest AND s.createdAt < :date_created_newest")
+/*
+ * RunnerInfo lookup
+ */
+@NamedQuery(name = "ImageStats.findByGhPR",
+        query = "SELECT s FROM ImageStats s WHERE s.runnerInfo.ghPR = :ghPR ORDER BY s.imageName")
+@NamedQuery(name = "ImageStats.findByRunnerInfoId",
+        query = "SELECT s FROM ImageStats s WHERE s.runnerInfo.id = :runnerInfoId ORDER BY s.imageName")
 //@formatter:on
 public class ImageStats extends TimestampedEntity {
     @JsonProperty("tag")
@@ -101,7 +109,7 @@ public class ImageStats extends TimestampedEntity {
     private ReachableImageStats reachableStats;
 
     @JsonProperty("runner_info")
-    @OneToOne(optional = true, cascade = CascadeType.PERSIST)
+    @ManyToOne(optional = true, cascade = CascadeType.MERGE)
     @JoinColumn(name = "runner_info_id")
     private RunnerInfo runnerInfo;
 

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/RunnerInfo.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/RunnerInfo.java
@@ -55,7 +55,7 @@ public class RunnerInfo extends PanacheEntity {
     private long memoryAvailableBytes;
     private String description;
     private String triggeredBy;
-    // We use undersoce for the column name for consistency with ImageStats.
+    // We use underscore for the column name for consistency with ImageStats.
     @Basic
     @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "created_at", nullable = false)

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/RunnerInfo.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/RunnerInfo.java
@@ -23,6 +23,8 @@ package com.redhat.quarkus.mandrel.collector.report.model;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Basic;
+import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.DiscriminatorType;
 import jakarta.persistence.Entity;
@@ -30,11 +32,15 @@ import jakarta.persistence.Index;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+
+import java.util.Date;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Entity
 @Table(name = "runner_info", indexes = {
-        @Index(columnList = "testVersion, graalvmVersion, quarkusVersion, jdkVersion, description, ghPR") })
+        @Index(columnList = "created_at, testVersion, graalvmVersion, quarkusVersion, jdkVersion, description, triggeredBy") })
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(discriminatorType = DiscriminatorType.INTEGER, name = "stats_type")
 public class RunnerInfo extends PanacheEntity {
@@ -48,7 +54,12 @@ public class RunnerInfo extends PanacheEntity {
     private long memorySizeBytes;
     private long memoryAvailableBytes;
     private String description;
-    private String ghPR;
+    private String triggeredBy;
+    // We use undersoce for the column name for consistency with ImageStats.
+    @Basic
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "created_at", nullable = false)
+    private Date createdAt;
 
     public String getTestVersion() {
         return testVersion;
@@ -122,11 +133,19 @@ public class RunnerInfo extends PanacheEntity {
         this.description = description;
     }
 
-    public String getGhPR() {
-        return ghPR;
+    public String getTriggeredBy() {
+        return triggeredBy;
     }
 
-    public void setGhPR(String ghPR) {
-        this.ghPR = ghPR;
+    public void setTriggeredBy(String triggeredBy) {
+        this.triggeredBy = triggeredBy;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
     }
 }

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/RunnerInfo.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/RunnerInfo.java
@@ -26,19 +26,21 @@ import io.quarkus.hibernate.orm.panache.PanacheEntity;
 import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.DiscriminatorType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Entity
-@Table(name = "runner_info")
+@Table(name = "runner_info", indexes = {
+        @Index(columnList = "testVersion, graalvmVersion, quarkusVersion, jdkVersion, description, ghPR") })
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(discriminatorType = DiscriminatorType.INTEGER, name = "stats_type")
 public class RunnerInfo extends PanacheEntity {
 
     private String testVersion;
-    private String mandrelVersion;
+    private String graalvmVersion;
     private String quarkusVersion;
     private String jdkVersion;
     private String operatingSystem;
@@ -46,6 +48,7 @@ public class RunnerInfo extends PanacheEntity {
     private long memorySizeBytes;
     private long memoryAvailableBytes;
     private String description;
+    private String ghPR;
 
     public String getTestVersion() {
         return testVersion;
@@ -55,12 +58,12 @@ public class RunnerInfo extends PanacheEntity {
         this.testVersion = testVersion;
     }
 
-    public String getMandrelVersion() {
-        return mandrelVersion;
+    public String getGraalvmVersion() {
+        return graalvmVersion;
     }
 
-    public void setMandrelVersion(String mandrelVersion) {
-        this.mandrelVersion = mandrelVersion;
+    public void setGraalvmVersion(String graalvmVersion) {
+        this.graalvmVersion = graalvmVersion;
     }
 
     public String getQuarkusVersion() {
@@ -117,5 +120,13 @@ public class RunnerInfo extends PanacheEntity {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public String getGhPR() {
+        return ghPR;
+    }
+
+    public void setGhPR(String ghPR) {
+        this.ghPR = ghPR;
     }
 }

--- a/src/test/java/com/redhat/quarkus/mandrel/collector/report/endpoints/GraalImageStatsResourceTest.java
+++ b/src/test/java/com/redhat/quarkus/mandrel/collector/report/endpoints/GraalImageStatsResourceTest.java
@@ -98,7 +98,7 @@ public class GraalImageStatsResourceTest {
         assertEquals("foo-bar", result.getImageName());
         assertEquals("Github Runner 2.315.0", result.getRunnerInfo().getDescription());
         assertEquals(274877906944L, result.getRunnerInfo().getMemorySizeBytes());
-        assertEquals("https://github.com/quarkusio/quarkus/pull/31490", result.getRunnerInfo().getGhPR());
+        assertEquals("https://github.com/quarkusio/quarkus/pull/31490", result.getRunnerInfo().getTriggeredBy());
 
         // Ensure we can listOne the result
         given().contentType(ContentType.JSON).header("token", token).when()

--- a/src/test/java/com/redhat/quarkus/mandrel/collector/report/endpoints/ImageStatsResourceTest.java
+++ b/src/test/java/com/redhat/quarkus/mandrel/collector/report/endpoints/ImageStatsResourceTest.java
@@ -47,6 +47,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -83,22 +84,22 @@ public class ImageStatsResourceTest {
                 .when().post(StatsTestHelper.BASE_URL + "/runner-info").body().as(RunnerInfo.class);
 
         final ImageStats rA = given().contentType(ContentType.JSON).header("token", token).body(resultA)
-                .when().post(StatsTestHelper.BASE_URL + "/import?t=mehTagA" + "&rid=" + r1.id).body().as(ImageStats.class);
+                .when().post(StatsTestHelper.BASE_URL + "/import?t=mehTagA" + "&runnerid=" + r1.id).body().as(ImageStats.class);
         final ImageStats rB = given().contentType(ContentType.JSON).header("token", token).body(resultB)
-                .when().post(StatsTestHelper.BASE_URL + "/import?t=mehTagB" + "&rid=" + r1.id).body().as(ImageStats.class);
+                .when().post(StatsTestHelper.BASE_URL + "/import?t=mehTagB" + "&runnerid=" + r1.id).body().as(ImageStats.class);
         final ImageStats rC = given().contentType(ContentType.JSON).header("token", token).body(resultC)
-                .when().post(StatsTestHelper.BASE_URL + "/import?t=mehTagC" + "&rid=" + r1.id).body().as(ImageStats.class);
+                .when().post(StatsTestHelper.BASE_URL + "/import?t=mehTagC" + "&runnerid=" + r1.id).body().as(ImageStats.class);
 
         // Insert another run with another image stat:
         final RunnerInfo r2 = given().contentType(ContentType.JSON).header("token", token).body(runnerInfo2)
                 .when().post(StatsTestHelper.BASE_URL + "/runner-info").body().as(RunnerInfo.class);
 
         final ImageStats rD = given().contentType(ContentType.JSON).header("token", token).body(resultD)
-                .when().post(StatsTestHelper.BASE_URL + "/import?t=mehTagD" + "&rid=" + r2.id).body().as(ImageStats.class);
+                .when().post(StatsTestHelper.BASE_URL + "/import?t=mehTagD" + "&runnerid=" + r2.id).body().as(ImageStats.class);
         try {
 
             assertTrue(r1.id > 0);
-            assertEquals("https://github.com/quarkusio/quarkus/pull/66666666", r1.getGhPR());
+            assertEquals("https://github.com/quarkusio/quarkus/pull/66666666", r1.getTriggeredBy());
             assertEquals("Mandrel-23.1.1.0-Final", r1.getGraalvmVersion());
 
             assertTrue(rA.getId() > 0);
@@ -112,31 +113,34 @@ public class ImageStatsResourceTest {
             assertEquals("quarkus-integration-test-no-awt-999-SNAPSHOT-runner", rC.getImageName());
 
             assertTrue(r2.id > 0);
-            assertEquals("https://github.com/quarkusio/quarkus/pull/66666666", r2.getGhPR());
+            assertEquals("https://github.com/quarkusio/quarkus/pull/66666666", r2.getTriggeredBy());
             assertEquals("Mandrel-24.0.1.0-Final", r2.getGraalvmVersion());
 
             // Lookup all stats from all runs that belong to
             // a particular PR using RestAssured:
             final ImageStats[] results = given().when().contentType(ContentType.JSON).header("token", token)
-                    .get(StatsTestHelper.BASE_URL + "/lookup?ghPR=https://github.com/quarkusio/quarkus/pull/66666666").body()
+                    .get(StatsTestHelper.BASE_URL
+                            + "/lookup/runner-info/triggeredBy?key=https://github.com/quarkusio/quarkus/pull/66666666")
+                    .body()
                     .as(ImageStats[].class);
             assertEquals(4, results.length);
 
             final ImageStats[] run1Results = given().when().contentType(ContentType.JSON).header("token", token)
-                    .get(StatsTestHelper.BASE_URL + "/lookup?rid=" + r1.id).body()
+                    .get(StatsTestHelper.BASE_URL + "/lookup/runner-info/id?key=" + r1.id).body()
                     .as(ImageStats[].class);
             assertEquals(3, run1Results.length);
 
             final ImageStats[] run2Results = given().when().contentType(ContentType.JSON).header("token", token)
-                    .get(StatsTestHelper.BASE_URL + "/lookup?rid=" + r2.id).body()
+                    .get(StatsTestHelper.BASE_URL + "/lookup/runner-info/id?key=" + r2.id).body()
                     .as(ImageStats[].class);
             assertEquals(1, run2Results.length);
-            assertEquals("https://github.com/quarkusio/quarkus/pull/66666666", run2Results[0].getRunnerInfo().getGhPR());
+            assertEquals("https://github.com/quarkusio/quarkus/pull/66666666", run2Results[0].getRunnerInfo().getTriggeredBy());
             assertEquals("Mandrel-24.0.1.0-Final", run2Results[0].getRunnerInfo().getGraalvmVersion());
             assertEquals("quarkus-integration-test-jaxb-999-SNAPSHOT-runner", run2Results[0].getImageName());
 
+            TestUtil.checkLog();
         } finally {
-            // Delete ImgeStats:
+            // Delete ImageStats:
             Stream.of(rA.getId(), rB.getId(), rC.getId(), rD.getId()).forEach(id -> {
                 given().contentType(ContentType.JSON).header("token", token).when()
                         .delete(StatsTestHelper.BASE_URL + "/" + id).then().statusCode(200);
@@ -146,7 +150,138 @@ public class ImageStatsResourceTest {
                 given().contentType(ContentType.JSON).header("token", token).when()
                         .delete(StatsTestHelper.BASE_URL + "/runner-info/" + id).then().statusCode(200);
             });
+        }
+    }
+
+    @Test
+    public void testImportImageStatRunnerInfo() throws Exception {
+        final String originalTriggeredBy = "https://github.com/quarkusio/quarkus/pull/66666666";
+        final String newTriggeredBy = "https://github.com/quarkusio/quarkus/pull/77777777";
+        final String transformedImageStat = StatsTestHelper.getStatString("23.1/image-stats-import.json");
+        final String runnerInfoUpdate = StatsTestHelper.getStatString("23.1/image-stats-import-runner-update.json");
+        final String token = StatsTestHelper.login(Mode.READ_WRITE);
+        final List<Long> rIdToDelete = new ArrayList<>();
+        final List<Long> statsIdToDelete = new ArrayList<>();
+
+        try {
+            final RunnerInfo r1 = given().contentType(ContentType.JSON).header("token", token).body(runnerInfoUpdate)
+                    .when().post(StatsTestHelper.BASE_URL + "/runner-info").body().as(RunnerInfo.class);
+            rIdToDelete.add(r1.id);
+            final ImageStats rA = given().contentType(ContentType.JSON).header("token", token).body(transformedImageStat)
+                    .when().post(StatsTestHelper.BASE_URL).body().as(ImageStats.class);
+            statsIdToDelete.add(rA.getId());
+
+            assertTrue(r1.id > 0);
+            assertTrue(rA.getRunnerInfo().id > 0);
+            assertEquals(newTriggeredBy, r1.getTriggeredBy());
+            assertEquals(originalTriggeredBy, rA.getRunnerInfo().getTriggeredBy());
+
+            final ImageStats[] resultsNew = given().when().contentType(ContentType.JSON).header("token", token)
+                    .get(StatsTestHelper.BASE_URL + "/lookup/runner-info/triggeredBy?key=" + newTriggeredBy)
+                    .body()
+                    .as(ImageStats[].class);
+            assertEquals(0, resultsNew.length);
+
+            final ImageStats[] resultsOld = given().when().contentType(ContentType.JSON).header("token", token)
+                    .get(StatsTestHelper.BASE_URL + "/lookup/runner-info/triggeredBy?key=" + originalTriggeredBy)
+                    .body()
+                    .as(ImageStats[].class);
+            assertEquals(1, resultsOld.length);
+            assertEquals("quarkus-integration-test-no-awt-999-SNAPSHOT-runner-XXX", resultsOld[0].getImageName());
+
+            final Long oldRunnerInfoId = resultsOld[0].getRunnerInfo().id;
+            final ImageStats rANew = given().contentType(ContentType.JSON).header("token", token).body(transformedImageStat)
+                    .when().post(StatsTestHelper.BASE_URL + "/?runnerid=" + r1.id).body().as(ImageStats.class);
+            statsIdToDelete.add(rANew.getId());
+            final Long newRunnerInfoId = rANew.getRunnerInfo().id;
+
+            assertNotEquals(oldRunnerInfoId, newRunnerInfoId, "The original import contained a RunnerInfo record,"
+                    + "it should have been persisted with its own generated id. The new Runner Info with which this Image Stats "
+                    + "gets updated must have a different id.");
+            assertEquals(newTriggeredBy, r1.getTriggeredBy());
+            assertEquals(newTriggeredBy, rANew.getRunnerInfo().getTriggeredBy(),
+                    "triggered_by must have been updated from " + originalTriggeredBy + " to "
+                            + newTriggeredBy);
+            assertEquals("Mandrel-23.1.1.0-Final", rA.getRunnerInfo().getGraalvmVersion());
+            assertEquals("quarkus-integration-test-no-awt-999-SNAPSHOT-runner-XXX", rA.getImageName());
+
+            final ImageStats[] results = given().when().contentType(ContentType.JSON).header("token", token)
+                    .get(StatsTestHelper.BASE_URL + "/lookup/runner-info/triggeredBy?key=" + newTriggeredBy)
+                    .body()
+                    .as(ImageStats[].class);
+            assertEquals(1, results.length);
+            assertEquals("quarkus-integration-test-no-awt-999-SNAPSHOT-runner-XXX", results[0].getImageName());
+
             TestUtil.checkLog();
+        } finally {
+            // Delete ImageStats:
+            statsIdToDelete.forEach(id -> given().contentType(ContentType.JSON).header("token", token).when()
+                    .delete(StatsTestHelper.BASE_URL + "/" + id).then().statusCode(200));
+            // Delete RunnerInfo
+            rIdToDelete.forEach(id -> given().contentType(ContentType.JSON).header("token", token).when()
+                    .delete(StatsTestHelper.BASE_URL + "/runner-info/" + id).then().statusCode(200));
+        }
+    }
+
+    @Test
+    public void testRunnerInfoLookup() throws IOException {
+        final String statsTemplate = StatsTestHelper.getStatString("24.0/lookup/quarkus-template.json");
+        final String runnerTemplate = StatsTestHelper.getStatString("24.0/lookup/quarkus-runner-template.json");
+        final String token = StatsTestHelper.login(Mode.READ_WRITE);
+        final List<Long> rIdToDelete = new ArrayList<>();
+        final List<Long> statsIdToDelete = new ArrayList<>();
+
+        try {
+            // Why not parametrized test? I want the data in the db to rule out incorrect resultset.
+            final Map<String, String> data = Map.of(
+                    "@testVersion@", "My Test Version X",
+                    "@graalvmVersion@", "My GraalVM Version X",
+                    "@quarkusVersion@", "My Quarkus Version X",
+                    "@jdkVersion@", "My JDK Version X",
+                    "@description@", "My Description X",
+                    "@triggeredBy@", "My Triggered By X");
+            data.forEach((k, v) -> {
+                final RunnerInfo r1 = given().contentType(ContentType.JSON).header("token", token)
+                        .body(runnerTemplate.replace(k, v))
+                        .when().post(StatsTestHelper.BASE_URL + "/runner-info").body().as(RunnerInfo.class);
+                rIdToDelete.add(r1.id);
+                final ImageStats s1 = given().contentType(ContentType.JSON).header("token", token)
+                        .body(statsTemplate.replace("@NAME@", v))
+                        .when().post(StatsTestHelper.BASE_URL + "/import?runnerid=" + r1.id).body().as(ImageStats.class);
+                statsIdToDelete.add(s1.getId());
+            });
+
+            data.forEach((k, v) -> {
+                final String column = k.substring(1, k.length() - 1);
+                final String substring = v.substring(2, v.length() - 2);
+                ImageStats[] result = given().when().contentType(ContentType.JSON).header("token", token)
+                        .get(StatsTestHelper.BASE_URL + "/lookup/runner-info/" + column + "?key=" + v)
+                        .body()
+                        .as(ImageStats[].class);
+                assertEquals(1, result.length);
+                assertTrue(toJsonString(result[0].getRunnerInfo()).contains(v));
+                result = given().when().contentType(ContentType.JSON).header("token", token)
+                        .get(StatsTestHelper.BASE_URL + "/lookup/runner-info/" + column + "?key=" + substring)
+                        .body()
+                        .as(ImageStats[].class);
+                assertEquals(0, result.length);
+                result = given().when().contentType(ContentType.JSON).header("token", token)
+                        .get(StatsTestHelper.BASE_URL + "/lookup/runner-info/" + column + "?key=" + substring
+                                + "&wildcard=true")
+                        .body()
+                        .as(ImageStats[].class);
+                assertEquals(1, result.length);
+                assertTrue(toJsonString(result[0].getRunnerInfo()).contains(v));
+            });
+
+            TestUtil.checkLog();
+        } finally {
+            // Delete ImageStats:
+            statsIdToDelete.forEach(id -> given().contentType(ContentType.JSON).header("token", token).when()
+                    .delete(StatsTestHelper.BASE_URL + "/" + id).then().statusCode(200));
+            // Delete RunnerInfo
+            rIdToDelete.forEach(id -> given().contentType(ContentType.JSON).header("token", token).when()
+                    .delete(StatsTestHelper.BASE_URL + "/runner-info/" + id).then().statusCode(200));
         }
     }
 
@@ -184,6 +319,7 @@ public class ImageStatsResourceTest {
         // Now list one should no longer find the resource
         given().contentType(ContentType.JSON).header("token", rtoken).when()
                 .get(StatsTestHelper.BASE_URL + "/" + result.getId()).then().statusCode(204).body(is(""));
+        TestUtil.checkLog();
     }
 
     @Test
@@ -234,6 +370,7 @@ public class ImageStatsResourceTest {
 
         // no more image stats
         given().when().header("token", token).get(StatsTestHelper.BASE_URL).then().statusCode(200).body(is("[]"));
+        TestUtil.checkLog();
     }
 
     @Test
@@ -287,6 +424,7 @@ public class ImageStatsResourceTest {
 
         // no more image stats
         given().when().header("token", token).get(StatsTestHelper.BASE_URL).then().statusCode(200).body(is("[]"));
+        TestUtil.checkLog();
     }
 
     @Test
@@ -322,6 +460,7 @@ public class ImageStatsResourceTest {
         ImageStats[] deletedIds = given().contentType(ContentType.JSON).header("token", token).body(imageIdsJson).when()
                 .delete(StatsTestHelper.BASE_URL).body().as(ImageStats[].class);
         assertEquals(4, deletedIds.length);
+        TestUtil.checkLog();
     }
 
     @Test
@@ -365,6 +504,7 @@ public class ImageStatsResourceTest {
         // Now list one should no longer find the resource
         given().contentType(ContentType.JSON).header("token", token).when()
                 .get(StatsTestHelper.BASE_URL + "/" + result.getId()).then().statusCode(204).body(is(""));
+        TestUtil.checkLog();
     }
 
     @Test
@@ -417,10 +557,14 @@ public class ImageStatsResourceTest {
         return imageStats;
     }
 
-    public static String toJsonString(Object imageStats) throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.writeValue(baos, imageStats);
+    public static String toJsonString(Object imageStats) {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            objectMapper.writeValue(baos, imageStats);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to deserialize.", e);
+        }
         return baos.toString(StandardCharsets.UTF_8);
     }
 }

--- a/src/test/java/com/redhat/quarkus/mandrel/collector/report/endpoints/ResourceErrorsTest.java
+++ b/src/test/java/com/redhat/quarkus/mandrel/collector/report/endpoints/ResourceErrorsTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2024 Contributors to the Collector project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.redhat.quarkus.mandrel.collector.report.endpoints;
+
+import com.redhat.quarkus.mandrel.collector.report.endpoints.StatsTestHelper.Mode;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.parsing.Parser;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+
+@QuarkusTest
+@Order(Order.DEFAULT + 999)
+public class ResourceErrorsTest {
+
+    @BeforeAll
+    public static void setup() {
+        RestAssured.defaultParser = Parser.JSON;
+    }
+
+    @Test
+    public void testImportErrors() {
+        final String token = StatsTestHelper.login(Mode.READ_WRITE);
+
+        given()
+                .contentType(ContentType.JSON)
+                .header("token", token)
+                .body(StatsTestHelper.getStatString("23.1/quarkus-awt.json"))
+                .when()
+                .post(StatsTestHelper.BASE_URL + "/import?t=mehTagA&runnerid=blabla")
+                .then()
+                .statusCode(404)
+                .body("exceptionType", containsString("NotFoundException"));
+
+        given()
+                .contentType(ContentType.JSON)
+                .header("token", token)
+                .body(StatsTestHelper.getStatString("23.1/quarkus-awt.json"))
+                .when()
+                .post(StatsTestHelper.BASE_URL + "/import?t=mehTagA&runnerid=55555555555")
+                .then()
+                .statusCode(404)
+                .body("error", containsString("RunnerInfo with ID 55555555555 not found."));
+
+        given()
+                .contentType(ContentType.JSON)
+                .header("token", token)
+                .when()
+                .post(StatsTestHelper.BASE_URL)
+                .then()
+                .statusCode(400)
+                .body("error", containsString("ImageStats must not be null"));
+
+        given()
+                .contentType(ContentType.JSON)
+                .header("token", token)
+                .when()
+                .post(StatsTestHelper.BASE_URL + "/import")
+                .then()
+                .statusCode(400)
+                .body("error", containsString("GraalStats must not be null"));
+
+        given()
+                .contentType(ContentType.JSON)
+                .header("token", token)
+                .when()
+                .put(StatsTestHelper.BASE_URL + "/666")
+                .then()
+                .statusCode(400)
+                .body("error", containsString("GraalBuildInfo for statId 666 must not be null"));
+
+        given()
+                .contentType(ContentType.JSON)
+                .header("token", token)
+                .body(StatsTestHelper.getStatString("23.1/quarkus-awt.json"))
+                .when()
+                .put(StatsTestHelper.BASE_URL + "/666")
+                .then()
+                .statusCode(404)
+                .body("error", containsString("Stat with id 666 not found"));
+
+        given()
+                .contentType(ContentType.JSON)
+                .header("token", token)
+                .when()
+                .post(StatsTestHelper.BASE_URL + "/update-runner-info/666")
+                .then()
+                .statusCode(400)
+                .body("error", containsString("RunnerInfo for statId 666 must not be null"));
+
+        given()
+                .contentType(ContentType.JSON)
+                .header("token", token)
+                .body(StatsTestHelper.getStatString("23.1/quarkus-runner.json"))
+                .when()
+                .post(StatsTestHelper.BASE_URL + "/update-runner-info/666")
+                .then()
+                .statusCode(404)
+                .body("error", containsString("Stat with id 666 not found"));
+
+        given()
+                .contentType(ContentType.JSON)
+                .header("token", token)
+                .when()
+                .post(StatsTestHelper.BASE_URL + "/runner-info")
+                .then()
+                .statusCode(400)
+                .body("error", containsString("RunnerInfo must not be null"));
+
+        given()
+                .contentType(ContentType.JSON)
+                .header("token", token)
+                .when()
+                .delete(StatsTestHelper.BASE_URL + "/runner-info/")
+                .then()
+                .statusCode(405)
+                .body("exceptionType", containsString("NotAllowedException"));
+
+        given()
+                .contentType(ContentType.JSON)
+                .header("token", token)
+                .when()
+                .delete(StatsTestHelper.BASE_URL + "/runner-info/mustBeInteger")
+                .then()
+                .statusCode(404)
+                .body("error", containsString("Unable to find matching target resource method"));
+
+        given()
+                .contentType(ContentType.JSON)
+                .header("token", token)
+                .when()
+                .delete(StatsTestHelper.BASE_URL + "/runner-info/666")
+                .then()
+                .statusCode(404)
+                .body("error", containsString("RunnerInfo with ID 666 not found"));
+
+        given()
+                .contentType(ContentType.JSON)
+                .header("token", token)
+                .when()
+                .delete(StatsTestHelper.BASE_URL + "/666")
+                .then()
+                .statusCode(404)
+                .body("error", containsString("ImageStats with ID 666 not found"));
+
+        given()
+                .contentType(ContentType.JSON)
+                .header("token", token)
+                .when()
+                .delete(StatsTestHelper.BASE_URL)
+                .then()
+                .statusCode(400)
+                .body("error", containsString("ids must not be null"));
+
+        given()
+                .contentType(ContentType.JSON)
+                .header("token", token)
+                .when()
+                .delete(StatsTestHelper.BASE_URL + "/image-name/NAME?dateNewest=2022-07-05 15:27:54.794")
+                .then()
+                .statusCode(400)
+                .body("error", containsString("imageName, dateOldest and dateNewest must be set"));
+
+        given().contentType(ContentType.JSON).header("token", token)
+                .when()
+                .get(StatsTestHelper.BASE_URL + "/lookup/runner-info/XXX?key=YYY")
+                .then()
+                .statusCode(400)
+                .body("error", containsString(
+                        "column must be one of id, testVersion, graalvmVersion, quarkusVersion, jdkVersion, description, triggeredBy"));
+
+        given().contentType(ContentType.JSON).header("token", token)
+                .when()
+                .get(StatsTestHelper.BASE_URL + "/lookup/runner-info/testVersion?Blaba=Blabla")
+                .then()
+                .statusCode(400)
+                .body("error", containsString("key must not be null"));
+    }
+}

--- a/src/test/java/com/redhat/quarkus/mandrel/collector/report/endpoints/ResourceErrorsTestIT.java
+++ b/src/test/java/com/redhat/quarkus/mandrel/collector/report/endpoints/ResourceErrorsTestIT.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024 Contributors to the Collector project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.redhat.quarkus.mandrel.collector.report.endpoints;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class ResourceErrorsTestIT extends ResourceErrorsTest {
+}

--- a/src/test/resources/22.3/c-runner.json
+++ b/src/test/resources/22.3/c-runner.json
@@ -1,11 +1,12 @@
 {
   "test_version": "1.0.0",
-  "mandrel_version": "22.3.0",
+  "graalvm_version": "22.3.0",
   "quarkus_version": "2.13.3.Final",
   "jdk_version": "17.0.7",
   "operating_system": "Linux",
   "architecture": "x86_64",
   "memory_size_bytes": 274877906944,
   "memory_available_bytes": 174811906921,
-  "description": "Github Runner 2.315.0"
+  "description": "Github Runner 2.315.0",
+  "gh_pr": "https://github.com/quarkusio/quarkus/pull/31490"
 }

--- a/src/test/resources/22.3/c-runner.json
+++ b/src/test/resources/22.3/c-runner.json
@@ -8,5 +8,5 @@
   "memory_size_bytes": 274877906944,
   "memory_available_bytes": 174811906921,
   "description": "Github Runner 2.315.0",
-  "gh_pr": "https://github.com/quarkusio/quarkus/pull/31490"
+  "triggered_by": "https://github.com/quarkusio/quarkus/pull/31490"
 }

--- a/src/test/resources/23.1/image-stats-import-runner-update.json
+++ b/src/test/resources/23.1/image-stats-import-runner-update.json
@@ -8,5 +8,5 @@
   "memory_size_bytes": 66847330304,
   "memory_available_bytes": 174811906921,
   "description": "Quarkus Integration Tests",
-  "triggered_by": "https://github.com/quarkusio/quarkus/pull/66666666"
+  "triggered_by": "https://github.com/quarkusio/quarkus/pull/77777777"
 }

--- a/src/test/resources/23.1/image-stats-import-runner-update.json
+++ b/src/test/resources/23.1/image-stats-import-runner-update.json
@@ -6,7 +6,7 @@
   "operating_system": "Linux",
   "architecture": "x86_64",
   "memory_size_bytes": 66847330304,
-  "memory_available_bytes": 174811906921,
+  "memory_available_bytes": 22847330304,
   "description": "Quarkus Integration Tests",
   "triggered_by": "https://github.com/quarkusio/quarkus/pull/77777777"
 }

--- a/src/test/resources/23.1/image-stats-import.json
+++ b/src/test/resources/23.1/image-stats-import.json
@@ -1,0 +1,54 @@
+{
+  "tag": "mehTagC",
+  "img_name": "quarkus-integration-test-no-awt-999-SNAPSHOT-runner-XXX",
+  "generator_version": "Mandrel-23.1.1.0-Final",
+  "image_size_stats": {
+    "total_bytes": 60671704,
+    "code_cache_bytes": 28291136,
+    "heap_bytes": 31965184,
+    "resources_bytes": 1613728,
+    "resources_count": 202,
+    "other_bytes": 415384,
+    "debuginfo_bytes": 0
+  },
+  "jni_classes_stats": {
+    "classes": 61,
+    "fields": 59,
+    "methods": 55
+  },
+  "reflection_stats": {
+    "classes": 3949,
+    "fields": 117,
+    "methods": 3178
+  },
+  "build_perf_stats": {
+    "total_build_time_sec": 55.51219548,
+    "gc_time_sec": 5.33,
+    "num_cpu_cores": 16,
+    "total_machine_memory": 66847330304,
+    "peak_rss_bytes": 4822646784,
+    "cpu_load": 11.908436489648643
+  },
+  "total_classes_stats": {
+    "classes": 14313,
+    "fields": 32144,
+    "methods": 112776
+  },
+  "reachability_stats": {
+    "classes": 12320,
+    "fields": 19161,
+    "methods": 62871
+  },
+  "runner_info": {
+    "test_version": "999-SNAPSHOT 9fc4e97d",
+    "graalvm_version": "Mandrel-23.1.1.0-Final",
+    "quarkus_version": "999-SNAPSHOT",
+    "jdk_version": "21.0.1+12-LTS",
+    "operating_system": "Linux",
+    "architecture": "x86_64",
+    "memory_size_bytes": 66847330304,
+    "memory_available_bytes": 174811906921,
+    "description": "Quarkus Integration Tests",
+    "triggered_by": "https://github.com/quarkusio/quarkus/pull/66666666"
+  }
+}

--- a/src/test/resources/23.1/quarkus-awt.json
+++ b/src/test/resources/23.1/quarkus-awt.json
@@ -1,0 +1,75 @@
+{
+  "resource_usage": {
+    "memory": {
+      "system_total": 66847330304,
+      "peak_rss_bytes": 5519212544
+    },
+    "garbage_collection": {
+      "count": 76,
+      "total_secs": 5.44,
+      "max_heap": 21368930304
+    },
+    "cpu": {
+      "load": 11.37145285732967,
+      "parallelism": 16,
+      "total_cores": 16
+    },
+    "total_secs": 60.653102704999995
+  },
+  "image_details": {
+    "code_area": {
+      "bytes": 36931424,
+      "compilation_units": 50223
+    },
+    "total_bytes": 77318128,
+    "image_heap": {
+      "bytes": 39964672,
+      "objects": {
+        "count": 384718
+      },
+      "resources": {
+        "bytes": 3537416,
+        "count": 360
+      }
+    }
+  },
+  "general_info": {
+    "c_compiler": "gcc (redhat, x86_64, 11.4.1)",
+    "name": "quarkus-integration-test-awt-999-SNAPSHOT-runner",
+    "java_version": "21.0.1+12-LTS",
+    "garbage_collector": "Serial GC",
+    "graal_compiler": {
+      "march": "x86-64-v3",
+      "optimization_level": "2"
+    },
+    "vendor_version": "Mandrel-23.1.1.0-Final",
+    "graalvm_version": "Mandrel-23.1.1.0-Final"
+  },
+  "analysis_results": {
+    "types": {
+      "total": 16574,
+      "reflection": 4436,
+      "jni": 191,
+      "reachable": 14244
+    },
+    "methods": {
+      "foreign_downcalls": -1,
+      "total": 131526,
+      "reflection": 3337,
+      "jni": 2391,
+      "reachable": 76048
+    },
+    "classes": {
+      "total": 16574,
+      "reflection": 4436,
+      "jni": 191,
+      "reachable": 14244
+    },
+    "fields": {
+      "total": 40366,
+      "reflection": 142,
+      "jni": 1708,
+      "reachable": 25056
+    }
+  }
+}

--- a/src/test/resources/23.1/quarkus-main.json
+++ b/src/test/resources/23.1/quarkus-main.json
@@ -1,0 +1,75 @@
+{
+  "resource_usage": {
+    "memory": {
+      "system_total": 66847330304,
+      "peak_rss_bytes": 8966524928
+    },
+    "garbage_collection": {
+      "count": 133,
+      "total_secs": 11.538,
+      "max_heap": 19838533632
+    },
+    "cpu": {
+      "load": 10.959016772166521,
+      "parallelism": 16,
+      "total_cores": 16
+    },
+    "total_secs": 107.671316924
+  },
+  "image_details": {
+    "code_area": {
+      "bytes": 64762176,
+      "compilation_units": 100013
+    },
+    "total_bytes": 146318448,
+    "image_heap": {
+      "bytes": 81121280,
+      "objects": {
+        "count": 670204
+      },
+      "resources": {
+        "bytes": 9014096,
+        "count": 419
+      }
+    }
+  },
+  "general_info": {
+    "c_compiler": "gcc (redhat, x86_64, 8.5.0)",
+    "name": "quarkus-integration-test-main-999-SNAPSHOT-runner",
+    "java_version": "21.0.2+13-LTS",
+    "garbage_collector": "Serial GC",
+    "graal_compiler": {
+      "march": "x86-64-v3",
+      "optimization_level": "2"
+    },
+    "vendor_version": "Mandrel-23.1.2.0-Final",
+    "graalvm_version": "Mandrel-23.1.2.0-Final"
+  },
+  "analysis_results": {
+    "types": {
+      "total": 33686,
+      "reflection": 9156,
+      "jni": 62,
+      "reachable": 30499
+    },
+    "methods": {
+      "foreign_downcalls": -1,
+      "total": 258465,
+      "reflection": 7683,
+      "jni": 55,
+      "reachable": 151471
+    },
+    "classes": {
+      "total": 33686,
+      "reflection": 9156,
+      "jni": 62,
+      "reachable": 30499
+    },
+    "fields": {
+      "total": 69533,
+      "reflection": 489,
+      "jni": 63,
+      "reachable": 44376
+    }
+  }
+}

--- a/src/test/resources/23.1/quarkus-no-awt.json
+++ b/src/test/resources/23.1/quarkus-no-awt.json
@@ -1,0 +1,75 @@
+{
+  "resource_usage": {
+    "memory": {
+      "system_total": 66847330304,
+      "peak_rss_bytes": 4822646784
+    },
+    "garbage_collection": {
+      "count": 85,
+      "total_secs": 5.33,
+      "max_heap": 20501757952
+    },
+    "cpu": {
+      "load": 11.908436489648643,
+      "parallelism": 16,
+      "total_cores": 16
+    },
+    "total_secs": 55.51219548
+  },
+  "image_details": {
+    "code_area": {
+      "bytes": 28291136,
+      "compilation_units": 40340
+    },
+    "total_bytes": 60671704,
+    "image_heap": {
+      "bytes": 31965184,
+      "objects": {
+        "count": 320606
+      },
+      "resources": {
+        "bytes": 1613728,
+        "count": 202
+      }
+    }
+  },
+  "general_info": {
+    "c_compiler": "gcc (redhat, x86_64, 11.4.1)",
+    "name": "quarkus-integration-test-no-awt-999-SNAPSHOT-runner",
+    "java_version": "21.0.1+12-LTS",
+    "garbage_collector": "Serial GC",
+    "graal_compiler": {
+      "march": "x86-64-v3",
+      "optimization_level": "2"
+    },
+    "vendor_version": "Mandrel-23.1.1.0-Final",
+    "graalvm_version": "Mandrel-23.1.1.0-Final"
+  },
+  "analysis_results": {
+    "types": {
+      "total": 14313,
+      "reflection": 3949,
+      "jni": 61,
+      "reachable": 12320
+    },
+    "methods": {
+      "foreign_downcalls": -1,
+      "total": 112776,
+      "reflection": 3178,
+      "jni": 55,
+      "reachable": 62871
+    },
+    "classes": {
+      "total": 14313,
+      "reflection": 3949,
+      "jni": 61,
+      "reachable": 12320
+    },
+    "fields": {
+      "total": 32144,
+      "reflection": 117,
+      "jni": 59,
+      "reachable": 19161
+    }
+  }
+}

--- a/src/test/resources/23.1/quarkus-runner.json
+++ b/src/test/resources/23.1/quarkus-runner.json
@@ -6,7 +6,7 @@
   "operating_system": "Linux",
   "architecture": "x86_64",
   "memory_size_bytes": 66847330304,
-  "memory_available_bytes": 174811906921,
+  "memory_available_bytes": 22847330304,
   "description": "Quarkus Integration Tests",
   "triggered_by": "https://github.com/quarkusio/quarkus/pull/66666666"
 }

--- a/src/test/resources/23.1/quarkus-runner.json
+++ b/src/test/resources/23.1/quarkus-runner.json
@@ -1,0 +1,12 @@
+{
+  "test_version": "999-SNAPSHOT 9fc4e97d",
+  "graalvm_version": "Mandrel-23.1.1.0-Final",
+  "quarkus_version": "999-SNAPSHOT",
+  "jdk_version": "21.0.1+12-LTS",
+  "operating_system": "Linux",
+  "architecture": "x86_64",
+  "memory_size_bytes": 66847330304,
+  "memory_available_bytes": 174811906921,
+  "description": "Quarkus Integration Tests",
+  "gh_pr": "https://github.com/quarkusio/quarkus/pull/66666666"
+}

--- a/src/test/resources/24.0/c-runner-missing-stuff.json
+++ b/src/test/resources/24.0/c-runner-missing-stuff.json
@@ -9,6 +9,6 @@
 # "architecture": "x86_64",
   "memory_size_bytes": 274877906944,
   "memory_available_bytes": 174811906921,
-# "gh_pr": "https://github.com/quarkusio/quarkus/pull/31490",
+# "triggered_by": "https://github.com/quarkusio/quarkus/pull/31490",
   "description": "Github Runner 666"
 }

--- a/src/test/resources/24.0/c-runner-missing-stuff.json
+++ b/src/test/resources/24.0/c-runner-missing-stuff.json
@@ -1,12 +1,14 @@
-# We drop # prefied "comments" like this from the string.
+# In the test harness, we drop # prefixed "comments"
+# like this from the string.
 {
   "test_version": "1.0.0",
-  "mandrel_version": "24.0.0",
+  "graalvm_version": "24.0.0",
   "quarkus_version": "3.8.4.Final",
   "jdk_version": "17.0.7",
-#  "operating_system": "Linux",
-#  "architecture": "x86_64",
+# "operating_system": "Linux",
+# "architecture": "x86_64",
   "memory_size_bytes": 274877906944,
   "memory_available_bytes": 174811906921,
+# "gh_pr": "https://github.com/quarkusio/quarkus/pull/31490",
   "description": "Github Runner 666"
 }

--- a/src/test/resources/24.0/lookup/quarkus-runner-template.json
+++ b/src/test/resources/24.0/lookup/quarkus-runner-template.json
@@ -1,0 +1,12 @@
+{
+  "test_version": "@testVersion@",
+  "graalvm_version": "@graalvmVersion@",
+  "quarkus_version": "@quarkusVersion@",
+  "jdk_version": "@jdkVersion@",
+  "operating_system": "Linux",
+  "architecture": "x86_64",
+  "memory_size_bytes": 174877906944,
+  "memory_available_bytes": 124811906921,
+  "description": "@description@",
+  "triggered_by": "@triggeredBy@"
+}

--- a/src/test/resources/24.0/lookup/quarkus-template.json
+++ b/src/test/resources/24.0/lookup/quarkus-template.json
@@ -1,0 +1,75 @@
+{
+  "resource_usage": {
+    "memory": {
+      "system_total": 66847330304,
+      "peak_rss_bytes": 4647596032
+    },
+    "garbage_collection": {
+      "count": 105,
+      "total_secs": 7.059,
+      "max_heap": 28445245440
+    },
+    "cpu": {
+      "load": 11.83869625159327,
+      "parallelism": 16,
+      "total_cores": 16
+    },
+    "total_secs": 76.382668491
+  },
+  "image_details": {
+    "code_area": {
+      "bytes": 30654656,
+      "compilation_units": 44280
+    },
+    "total_bytes": 64347784,
+    "image_heap": {
+      "bytes": 33271808,
+      "objects": {
+        "count": 342234
+      },
+      "resources": {
+        "bytes": 259048,
+        "count": 142
+      }
+    }
+  },
+  "general_info": {
+    "c_compiler": "gcc (redhat, x86_64, 11.4.1)",
+    "name": "@NAME@",
+    "java_version": "22.0.1+8",
+    "garbage_collector": "Serial GC",
+    "graal_compiler": {
+      "march": "x86-64-v3",
+      "optimization_level": "2"
+    },
+    "vendor_version": "Mandrel-24.0.1.0-Final",
+    "graalvm_version": "Mandrel-24.0.1.0-Final"
+  },
+  "analysis_results": {
+    "types": {
+      "total": 15644,
+      "reflection": 4426,
+      "jni": 61,
+      "reachable": 13375
+    },
+    "methods": {
+      "foreign_downcalls": -1,
+      "total": 121113,
+      "reflection": 3604,
+      "jni": 55,
+      "reachable": 68360
+    },
+    "classes": {
+      "total": 15644,
+      "reflection": 4426,
+      "jni": 61,
+      "reachable": 13375
+    },
+    "fields": {
+      "total": 39430,
+      "reflection": 136,
+      "jni": 61,
+      "reachable": 20329
+    }
+  }
+}

--- a/src/test/resources/24.0/quarkus-jaxb.json
+++ b/src/test/resources/24.0/quarkus-jaxb.json
@@ -1,0 +1,75 @@
+{
+  "resource_usage": {
+    "memory": {
+      "system_total": 66847330304,
+      "peak_rss_bytes": 4647596032
+    },
+    "garbage_collection": {
+      "count": 105,
+      "total_secs": 7.059,
+      "max_heap": 28445245440
+    },
+    "cpu": {
+      "load": 11.83869625159327,
+      "parallelism": 16,
+      "total_cores": 16
+    },
+    "total_secs": 76.382668491
+  },
+  "image_details": {
+    "code_area": {
+      "bytes": 30654656,
+      "compilation_units": 44280
+    },
+    "total_bytes": 64347784,
+    "image_heap": {
+      "bytes": 33271808,
+      "objects": {
+        "count": 342234
+      },
+      "resources": {
+        "bytes": 259048,
+        "count": 142
+      }
+    }
+  },
+  "general_info": {
+    "c_compiler": "gcc (redhat, x86_64, 11.4.1)",
+    "name": "quarkus-integration-test-jaxb-999-SNAPSHOT-runner",
+    "java_version": "22.0.1+8",
+    "garbage_collector": "Serial GC",
+    "graal_compiler": {
+      "march": "x86-64-v3",
+      "optimization_level": "2"
+    },
+    "vendor_version": "Mandrel-24.0.1.0-Final",
+    "graalvm_version": "Mandrel-24.0.1.0-Final"
+  },
+  "analysis_results": {
+    "types": {
+      "total": 15644,
+      "reflection": 4426,
+      "jni": 61,
+      "reachable": 13375
+    },
+    "methods": {
+      "foreign_downcalls": -1,
+      "total": 121113,
+      "reflection": 3604,
+      "jni": 55,
+      "reachable": 68360
+    },
+    "classes": {
+      "total": 15644,
+      "reflection": 4426,
+      "jni": 61,
+      "reachable": 13375
+    },
+    "fields": {
+      "total": 39430,
+      "reflection": 136,
+      "jni": 61,
+      "reachable": 20329
+    }
+  }
+}

--- a/src/test/resources/24.0/quarkus-runner.json
+++ b/src/test/resources/24.0/quarkus-runner.json
@@ -8,5 +8,5 @@
   "memory_size_bytes": 174877906944,
   "memory_available_bytes": 124811906921,
   "description": "Quarkus Integration Tests",
-  "gh_pr": "https://github.com/quarkusio/quarkus/pull/66666666"
+  "triggered_by": "https://github.com/quarkusio/quarkus/pull/66666666"
 }

--- a/src/test/resources/24.0/quarkus-runner.json
+++ b/src/test/resources/24.0/quarkus-runner.json
@@ -1,0 +1,12 @@
+{
+  "test_version": "999-SNAPSHOT 9fc4e97d",
+  "graalvm_version": "Mandrel-24.0.1.0-Final",
+  "quarkus_version": "999-SNAPSHOT",
+  "jdk_version": "22.0.1+8",
+  "operating_system": "Linux",
+  "architecture": "x86_64",
+  "memory_size_bytes": 174877906944,
+  "memory_available_bytes": 124811906921,
+  "description": "Quarkus Integration Tests",
+  "gh_pr": "https://github.com/quarkusio/quarkus/pull/66666666"
+}


### PR DESCRIPTION
This is a concept of what I would like to see as RunnerInfo mapping.

First, the old behavior is still possible, you can upload build image stats without any runner info.

Next, you can upload build image stats and then update it with runner info later, juts the way @zakkak started it.

In this PR, you can also create runner info first and then upload a barrage of various build image stats, tying those to that particular runner info.

Later, you can lookup e.g. all build image stats that concern runner info records that have a particular ghPR link
or you can list build image stats for a particular run.

The REST API feels wrong. When we started it, there was no lookup, no paging, just a plain dump it all endpoint. So I think we should polish the API, create some common lookup or search endpoint.  Editing API is easy as we own all clients, so I would prefer is we don't agonize over it too much here.
What requires much more serious attention is IMHO the database mapping, entities and attribute names. When ported to production, changing this could be a pain and it would require manual export/adapt/import steps.

Lemme know your thoughts pls.

Example from tests:

```java
 final ImageStats[] results = given().when().contentType(ContentType.JSON).header("token", token)
                    .get(StatsTestHelper.BASE_URL + "/lookup?ghPR=https://github.com/quarkusio/quarkus/pull/66666666").body()
                    .as(ImageStats[].class);
            assertEquals(4, results.length);

 final ImageStats[] run1Results = given().when().contentType(ContentType.JSON).header("token", token)
                    .get(StatsTestHelper.BASE_URL + "/lookup?rid=" + r1.id).body()
                    .as(ImageStats[].class);
            assertEquals(3, run1Results.length);
```