### PR TITLE
Update quarkus to 3.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,10 +9,10 @@
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.6.4</quarkus.platform.version>
-        <compiler-plugin.version>3.8.1</compiler-plugin.version>
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <compiler-plugin.version>3.10.1</compiler-plugin.version>
+        <quarkus.platform.version>3.8.5</quarkus.platform.version>
+        <compiler-plugin.version>3.12.1</compiler-plugin.version>
+        <surefire-plugin.version>3.2.3</surefire-plugin.version>
+        <compiler-plugin.version>3.12.1</compiler-plugin.version>
         <formatter-plugin.version>2.18.0</formatter-plugin.version>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.source>17</maven.compiler.source>
@@ -100,8 +100,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler-plugin.version}</version>
                 <configuration>
-                    <source>${maven.compiler.target}</source>
-                    <target>${maven.compiler.target}</target>
+                    <release>17</release>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Update done using `quarkus update -S 3.8`.
Note 3.8 is an LTS version.
