### PR TITLE
Extend image-stats `tag` endpoint to filter by image name

### DIFF
--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/endpoints/ImageStatsResource.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/endpoints/ImageStatsResource.java
@@ -99,7 +99,10 @@ public class ImageStatsResource {
     @RolesAllowed("token_read")
     @GET
     @Path("tag/{tag}")
-    public ImageStats[] getByTag(@PathParam("tag") String tag) {
+    public ImageStats[] getByTag(@PathParam("tag") String tag, @QueryParam("imgName") String imgName) {
+        if (!StringUtil.isNullOrEmpty(imgName)) {
+            return collection.getAllByImageNameAndTag(imgName, tag);
+        }
         return collection.getAllByTag(tag);
     }
 

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/ImageStats.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/ImageStats.java
@@ -43,6 +43,9 @@ import jakarta.persistence.Table;
 @NamedQuery(name = "ImageStats.findByImageName",
         query = "SELECT s FROM ImageStats s "
                 + "WHERE s.imageName = :image_name ORDER BY s.resourceStats.totalTimeSeconds, s.imageName, s.tag")
+@NamedQuery(name = "ImageStats.findByImageNameAndTag",
+        query = "SELECT s FROM ImageStats s "
+                + "WHERE s.imageName = :image_name AND s.tag = :tag_name ORDER BY s.createdAt")
 @NamedQuery(name = "ImageStats.distinctTags",
         query = "SELECT distinct s.tag FROM ImageStats s")
 /*

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/ImageStatsCollection.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/ImageStatsCollection.java
@@ -84,6 +84,13 @@ public class ImageStatsCollection {
                 .getResultList().toArray(new ImageStats[0]);
     }
 
+    public ImageStats[] getAllByImageNameAndTag(String imgName, String tag) {
+        return em.createNamedQuery("ImageStats.findByImageNameAndTag", ImageStats.class)
+                .setParameter("image_name", imgName)
+                .setParameter("tag_name", tag)
+                .getResultList().toArray(new ImageStats[0]);
+    }
+
     public String[] getDistinctTags() {
         return em.createNamedQuery("ImageStats.distinctTags", String.class).getResultList().toArray(new String[0]);
     }

--- a/src/test/java/com/redhat/quarkus/mandrel/collector/report/endpoints/ImageStatsResourceTest.java
+++ b/src/test/java/com/redhat/quarkus/mandrel/collector/report/endpoints/ImageStatsResourceTest.java
@@ -460,8 +460,20 @@ public class ImageStatsResourceTest {
         assertTrue(result.getId() > 0);
         statIds.add(result.getId());
 
+        // Find stats by tag and name
+        ImageStats[] results = given().when().contentType(ContentType.JSON).header("token", token).param("imgName", "foo-stat")
+                .get(StatsTestHelper.BASE_URL + "/tag/" + myTag).body().as(ImageStats[].class);
+        assertEquals(1, results.length);
+        for (ImageStats s : results) {
+            assertEquals(myTag, s.getTag());
+            assertEquals("foo-stat", s.getImageName());
+        }
+        results = given().when().contentType(ContentType.JSON).header("token", token).param("imgName", "third")
+                .get(StatsTestHelper.BASE_URL + "/tag/" + myTag).body().as(ImageStats[].class);
+        assertEquals(0, results.length);
+
         // Find stats by tag
-        ImageStats[] results = given().when().contentType(ContentType.JSON).header("token", token)
+        results = given().when().contentType(ContentType.JSON).header("token", token)
                 .get(StatsTestHelper.BASE_URL + "/tag/" + myTag).body().as(ImageStats[].class);
         assertEquals(2, results.length);
         for (ImageStats s : results) {


### PR DESCRIPTION
I was looking for a way to get data only for a specific test from a specific tag (and at a later I would like to add date-based filters (my goal is to be able to get only newer entries than I have already fetched).

I considered creating a new endpoint but this doesn't seem to scale well, so I thought we could start extending some of our existing endpoints instead, so here is a draft for this.

The reason I opened this as a draft is because I am toying with the idea of extending the base endpoint `api/v1/image-stats` with query params to filter the data according to various options.

@Karm @jerboaa WDYT is the best way to go?