### PR TITLE
Extend default image-stats endpoint

### DIFF
--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/endpoints/ImageStatsResource.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/endpoints/ImageStatsResource.java
@@ -82,11 +82,33 @@ public class ImageStatsResource {
     @Inject
     ImageStatsCollection collection;
 
+    /**
+     * List all ImageStats or based on tag, image name, or creation time.
+     *
+     * @param tag The tag to filter by
+     * @param imgName The image name to filter by
+     * @param newerThan The oldest creation time to filter by in yyyy-MM-dd HH:mm:ss.SSS format in UTC timezone
+     * @param olderThan The newest creation time to filter by in yyyy-MM-dd HH:mm:ss.SSS format in UTC timezone
+     * @return An array of ImageStats
+     */
     // TODO: Paging
     @RolesAllowed("token_read")
     @GET
-    public ImageStats[] list() {
-        return collection.getAll();
+    public ImageStats[] list(
+            @QueryParam("tag") String tag,
+            @QueryParam("imgName") String imgName,
+            @QueryParam("newerThan") String newerThan,
+            @QueryParam("olderThan") String olderThan) {
+        if (!StringUtil.isNullOrEmpty(tag) && !StringUtil.isNullOrEmpty(imgName)) {
+            return collection.getAllByImageNameAndTag(newerThan, olderThan, imgName, tag);
+        }
+        if (!StringUtil.isNullOrEmpty(tag)) {
+            return collection.getAllByTag(newerThan, olderThan, tag);
+        }
+        if (!StringUtil.isNullOrEmpty(imgName)) {
+            return collection.getAllByImageName(newerThan, olderThan, imgName);
+        }
+        return collection.getAll(newerThan, olderThan);
     }
 
     @RolesAllowed("token_read")

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/ImageStats.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/ImageStats.java
@@ -38,11 +38,24 @@ import jakarta.persistence.Table;
 //@formatter:off
 @NamedQuery(name = "ImageStats.findAll",
         query = "SELECT s FROM ImageStats s ORDER BY s.imageName")
+@NamedQuery(name = "ImageStats.findAllByDate",
+        query = "SELECT s FROM ImageStats s WHERE s.createdAt > :range_start AND s.createdAt < :range_end ORDER BY s.imageName")
 @NamedQuery(name = "ImageStats.findByTag",
         query = "SELECT s FROM ImageStats s WHERE s.tag = :tag_name ORDER BY s.tag, s.imageName")
+@NamedQuery(name = "ImageStats.findByTagAndDate",
+        query = "SELECT s FROM ImageStats s WHERE s.createdAt > :range_start AND s.createdAt < :range_end AND s.tag = :tag_name ORDER BY s.tag, s.imageName")
 @NamedQuery(name = "ImageStats.findByImageName",
         query = "SELECT s FROM ImageStats s "
                 + "WHERE s.imageName = :image_name ORDER BY s.resourceStats.totalTimeSeconds, s.imageName, s.tag")
+@NamedQuery(name = "ImageStats.findByImageNameAndDate",
+        query = "SELECT s FROM ImageStats s "
+                + "WHERE s.createdAt > :range_start AND s.createdAt < :range_end AND s.imageName = :image_name ORDER BY s.resourceStats.totalTimeSeconds, s.imageName, s.tag")
+@NamedQuery(name = "ImageStats.findByImageNameAndTag",
+        query = "SELECT s FROM ImageStats s "
+                + "WHERE s.imageName = :image_name AND s.tag = :tag_name ORDER BY s.createdAt")
+@NamedQuery(name = "ImageStats.findByImageNameAndTagAndDate",
+        query = "SELECT s FROM ImageStats s "
+                + "WHERE s.createdAt > :range_start AND s.createdAt < :range_end AND s.imageName = :image_name AND s.tag = :tag_name ORDER BY s.createdAt")
 @NamedQuery(name = "ImageStats.distinctTags",
         query = "SELECT distinct s.tag FROM ImageStats s")
 /*

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/ImageStatsCollection.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/ImageStatsCollection.java
@@ -67,7 +67,10 @@ public class ImageStatsCollection {
                 em.persist(stat.getRunnerInfo());
             }
         }
-        stat.setCreatedAt(new Date());
+        // Don't override the creation date if it's already set.
+        if (stat.getCreatedAt() == null) {
+            stat.setCreatedAt(new Date());
+        }
         em.persist(stat);
         return stat;
     }

--- a/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/ImageStatsCollection.java
+++ b/src/main/java/com/redhat/quarkus/mandrel/collector/report/model/ImageStatsCollection.java
@@ -20,6 +20,7 @@
 
 package com.redhat.quarkus.mandrel.collector.report.model;
 
+import io.quarkus.runtime.util.StringUtil;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
@@ -28,6 +29,7 @@ import jakarta.transaction.Transactional;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Date;
@@ -70,17 +72,67 @@ public class ImageStatsCollection {
         return stat;
     }
 
-    public ImageStats[] getAll() {
-        return em.createNamedQuery("ImageStats.findAll", ImageStats.class).getResultList().toArray(new ImageStats[0]);
+    public ImageStats[] getAll(String newerThan, String olderThan) {
+        if (StringUtil.isNullOrEmpty(olderThan) && StringUtil.isNullOrEmpty(newerThan)) {
+            return em.createNamedQuery("ImageStats.findAll", ImageStats.class)
+                    .getResultList().toArray(new ImageStats[0]);
+        }
+        DateRange dateRange = DateRange.fromString(newerThan, olderThan);
+        return em.createNamedQuery("ImageStats.findAllByDate", ImageStats.class)
+                .setParameter("range_start", dateRange.start)
+                .setParameter("range_end", dateRange.end)
+                .getResultList().toArray(new ImageStats[0]);
     }
 
     public ImageStats[] getAllByTag(String tag) {
-        return em.createNamedQuery("ImageStats.findByTag", ImageStats.class).setParameter("tag_name", tag)
+        return getAllByTag(null, null, tag);
+    }
+
+    public ImageStats[] getAllByTag(String newerThan, String olderThan, String tag) {
+        if (StringUtil.isNullOrEmpty(olderThan) && StringUtil.isNullOrEmpty(newerThan)) {
+            return em.createNamedQuery("ImageStats.findByTag", ImageStats.class)
+                    .setParameter("tag_name", tag)
+                    .getResultList().toArray(new ImageStats[0]);
+        }
+        DateRange dateRange = DateRange.fromString(newerThan, olderThan);
+        return em.createNamedQuery("ImageStats.findByTagAndDate", ImageStats.class)
+                .setParameter("range_start", dateRange.start)
+                .setParameter("range_end", dateRange.end)
+                .setParameter("tag_name", tag)
                 .getResultList().toArray(new ImageStats[0]);
     }
 
     public ImageStats[] getAllByImageName(String imageName) {
-        return em.createNamedQuery("ImageStats.findByImageName", ImageStats.class).setParameter("image_name", imageName)
+        return getAllByImageName(null, null, imageName);
+    }
+
+    public ImageStats[] getAllByImageName(String newerThan, String olderThan, String imageName) {
+        if (StringUtil.isNullOrEmpty(olderThan) && StringUtil.isNullOrEmpty(newerThan)) {
+            return em.createNamedQuery("ImageStats.findByImageName", ImageStats.class)
+                    .setParameter("image_name", imageName)
+                    .getResultList().toArray(new ImageStats[0]);
+        }
+        DateRange dateRange = DateRange.fromString(newerThan, olderThan);
+        return em.createNamedQuery("ImageStats.findByImageNameAndDate", ImageStats.class)
+                .setParameter("range_start", dateRange.start)
+                .setParameter("range_end", dateRange.end)
+                .setParameter("image_name", imageName)
+                .getResultList().toArray(new ImageStats[0]);
+    }
+
+    public ImageStats[] getAllByImageNameAndTag(String newerThan, String olderThan, String imgName, String tag) {
+        if (StringUtil.isNullOrEmpty(newerThan) && StringUtil.isNullOrEmpty(olderThan)) {
+            return em.createNamedQuery("ImageStats.findByImageNameAndTag", ImageStats.class)
+                    .setParameter("image_name", imgName)
+                    .setParameter("tag_name", tag)
+                    .getResultList().toArray(new ImageStats[0]);
+        }
+        DateRange dateRange = DateRange.fromString(newerThan, olderThan);
+        return em.createNamedQuery("ImageStats.findByImageNameAndTagAndDate", ImageStats.class)
+                .setParameter("range_start", dateRange.start)
+                .setParameter("range_end", dateRange.end)
+                .setParameter("image_name", imgName)
+                .setParameter("tag_name", tag)
                 .getResultList().toArray(new ImageStats[0]);
     }
 
@@ -198,5 +250,41 @@ public class ImageStatsCollection {
         }
         em.remove(r);
         return r;
+    }
+}
+
+class DateRange {
+    final Date start;
+    final Date end;
+
+    private DateRange(Date start, Date end) {
+        this.start = start;
+        this.end = end;
+    }
+
+    /**
+     * Parse the start and end date strings and return a DateRange object.
+     * If one of the dates is null, it will be set to the minimum or maximum date accordingly.
+     */
+    static DateRange fromString(String start, String end) {
+        if (start == null) {
+            start = "1970-01-01 00:00:00.000";
+        }
+        if (end == null) {
+            end = LocalDateTime.now().format(ImageStatsCollection.CREATED_DATE_FORMATTER);
+        }
+        try {
+            final LocalDateTime startLocal = LocalDateTime.parse(start, ImageStatsCollection.CREATED_DATE_FORMATTER);
+            final LocalDateTime endLocal = LocalDateTime.parse(end, ImageStatsCollection.CREATED_DATE_FORMATTER);
+            if (startLocal.isAfter(endLocal)) {
+                throw new WebApplicationException("olderThan must be before newerThan", Response.Status.BAD_REQUEST);
+            }
+            Date startDate = Date.from(startLocal.toInstant(java.time.ZoneOffset.UTC));
+            Date endDate = Date.from(endLocal.toInstant(java.time.ZoneOffset.UTC));
+            return new DateRange(startDate, endDate);
+        } catch (Exception e) {
+            throw new WebApplicationException("Invalid date format. Use " + ImageStatsCollection.CREATED_DATE_FORMAT,
+                    Response.Status.BAD_REQUEST);
+        }
     }
 }

--- a/src/test/java/com/redhat/quarkus/mandrel/collector/report/endpoints/ImageStatsResourceTest.java
+++ b/src/test/java/com/redhat/quarkus/mandrel/collector/report/endpoints/ImageStatsResourceTest.java
@@ -44,6 +44,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -360,6 +361,9 @@ public class ImageStatsResourceTest {
         ImageStats result = body.as(ImageStats.class);
         assertEquals(imageStats.getGraalVersion(), result.getGraalVersion());
         assertEquals(imageStats.getImageName(), result.getImageName());
+        assertEquals(imageStats.getCreatedAt(), null);
+        assertNotEquals(result.getCreatedAt(), null);
+        assertTrue(result.getCreatedAt().getYear() == Date.from(LocalDateTime.now().toInstant(ZoneOffset.UTC)).getYear());
         assertTrue(result.getId() > 0);
 
         // Ensure we can listOne the result

--- a/src/test/java/com/redhat/quarkus/mandrel/collector/report/model/DateRangeTest.java
+++ b/src/test/java/com/redhat/quarkus/mandrel/collector/report/model/DateRangeTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2022, 2024 Contributors to the Collector project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.redhat.quarkus.mandrel.collector.report.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DateRangeTest {
+
+    public static final String START = "2020-01-01 00:00:00.000";
+    public static final String END = "2021-01-02 00:00:00.000";
+
+    @Test
+    void checkDateRangeNull() {
+        DateRange dateRange = DateRange.fromString(null, null);
+        String start = ImageStatsCollection.CREATED_DATE_FORMATTER.format(
+                dateRange.start.toInstant().atOffset(ZoneOffset.UTC));
+        assertEquals("1970-01-01 00:00:00.000", start);
+        long currentDate = LocalDateTime.now().atOffset(ZoneOffset.UTC).toInstant().toEpochMilli();
+        long end = dateRange.end.toInstant().atOffset(ZoneOffset.UTC).toInstant().toEpochMilli();
+        assertTrue(currentDate - end >= 0);
+        assertTrue(currentDate - end < 500);
+    }
+
+    @Test
+    void checkDateRangeNullStart() {
+        DateRange dateRange = DateRange.fromString(null, END);
+        String start = ImageStatsCollection.CREATED_DATE_FORMATTER.format(
+                dateRange.start.toInstant().atOffset(ZoneOffset.UTC));
+        assertEquals("1970-01-01 00:00:00.000", start);
+    }
+
+    @Test
+    void checkDateRangeNullEnd() {
+        DateRange dateRange = DateRange.fromString(START, null);
+        long currentDate = LocalDateTime.now().atOffset(ZoneOffset.UTC).toInstant().toEpochMilli();
+        long end = dateRange.end.toInstant().atOffset(ZoneOffset.UTC).toInstant().toEpochMilli();
+        assertTrue(currentDate - end >= 0);
+        assertTrue(currentDate - end < 500);
+    }
+
+    @Test
+    void checkDateRange() {
+        DateRange dateRange = DateRange.fromString(START, END);
+        String start = ImageStatsCollection.CREATED_DATE_FORMATTER.format(
+                dateRange.start.toInstant().atOffset(ZoneOffset.UTC));
+        String end = ImageStatsCollection.CREATED_DATE_FORMATTER.format(
+                dateRange.end.toInstant().atOffset(ZoneOffset.UTC));
+        assertEquals(START, start);
+        assertEquals(END, end);
+    }
+}


### PR DESCRIPTION
I was looking for a way to get data only for a specific test from a specific tag that was run at specific period of time (my goal is to be able to get only newer entries than I have already fetched).

I considered creating a new endpoint but this doesn't seem to scale well, so I thought we could start extending some of our existing endpoints instead.

Note: This is related to https://github.com/Hyperfoil/Horreum/pull/1703

Supersedes https://github.com/Karm/collector/pull/34